### PR TITLE
#47 design: 초기화면 UI 구현

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,7 @@ import Attendance from './pages/Attendance';
 import Calendar from './pages/Calendar';
 import Home from './pages/Home';
 import Login from './pages/Login';
+import Signin from './pages/Signin';
 import Profile from './pages/Profile';
 import Signup from './pages/Signup';
 import EventDetails from './pages/EventDetails';
@@ -26,6 +27,7 @@ function App() {
     <ThemeProvider theme={theme}>
       <Routes>
         <Route path="/" element={<Login />} />
+        <Route path="/signin" element={<Signin />} />
         <Route path="/attendance" element={<Attendance />} />
         <Route path="/calendar" element={<Calendar />} />
         <Route path="/home" element={<Home />} />

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import styled, { ThemeProvider } from 'styled-components';
+import theme from '../styles/theme';
+// import SmallButton from '../components/Button/SmallButton';
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 370px;
+  height: 810px;
+`;
+
+const StyledTitle = styled.div`
+  width: 53%;
+  height: 76px;
+  margin: 297px 24% 126px 24%;
+  font-family: ${theme.font.family.pretendard_regular};
+  font-weight: 700;
+  font-size: 64px;
+  line-height: 76.38px;
+  color: #00DDA8;
+  text-align: center;
+`;
+
+/* const ButtonWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`; */
+
+
+/* const StyledButton = styled.button`
+  width: 85%;
+  height: 76px;
+  background-color: ${props => (props.primary ? '#00DDA8' : '#333333')};
+  color: ${props => (props.primary ? '#000000' : '#7f7f7f')};
+  font-family: ${props => props.theme.font.family.pretendard_semiBold};
+  font-size: 24px;
+  font-weight: 700;
+  margin-top: 20px;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+
+  &:hover {
+    opacity: 0.9;
+  }
+`; */
+
+const Login = () => {
+  return (
+    <ThemeProvider theme={theme}>
+      <Container>
+        <StyledTitle>Weeth</StyledTitle>
+        
+      </Container>
+    </ThemeProvider>
+  );
+};
+
+export default Login;
+
+/* <SmallButton color="#00DDA8" textColor="#000000" width="197px" height="76px">회원가입</SmallButton>
+          <SmallButton color="#333333" textColor="#7f7f7f" width="197px" height="76px">로그인</SmallButton> */

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -3,6 +3,8 @@ import styled, { ThemeProvider } from 'styled-components';
 import theme from '../styles/theme';
 import Button from '../components/Button/Button';
 
+/* 높이를 810px로 잡고 각각의 margin을 px로 잡았습니다 */
+
 const Container = styled.div`
   display: flex;
   flex-direction: column;
@@ -33,11 +35,11 @@ const ButtonWrapper = styled.div`
 
 const SignupButton = styled(Button)`
   width: 100%; /* Adjusted width */
-  margin-top: 126px;
 `;
 
 const LoginButton = styled(Button)`
   width: 100%; /* Adjusted width */
+  margin-bottom: 198px;
 `;
 
 const Login = () => {

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled, { ThemeProvider } from 'styled-components';
 import theme from '../styles/theme';
 import Button from '../components/Button/Button';
@@ -43,8 +44,10 @@ const LoginButton = styled(Button)`
 `;
 
 const Login = () => {
+  
   const [signupClicked, setSignupClicked] = useState(false);
   const [loginClicked, setLoginClicked] = useState(false);
+  const navi = useNavigate();
 
   const handleSignupClick = () => {
     setSignupClicked(!signupClicked);
@@ -62,14 +65,18 @@ const Login = () => {
           <SignupButton
             color={signupClicked ? "#0E9871" : theme.color.main.mainColor}
             textColor={signupClicked ? "#097154" : theme.color.grayScale.white} /* Temporary colors */
-            onClick={handleSignupClick}
+            onClick={(handleSignupClick) => {
+              navi(`/signup`);
+            }}
           >
             회원가입
           </SignupButton>
           <LoginButton
             color={loginClicked ? theme.color.grayScale.gray20 : theme.color.grayScale.gray30} /* Adjusted conditional logic */
             textColor={loginClicked ? theme.color.grayScale.gray12 : theme.color.grayScale.white} /* Temporary colors */
-            onClick={handleLoginClick}
+            onClick={(handleLoginClick) => {
+              navi(`/signin`); /* 경로 바꾸면 나중에 수정하기 */
+            }}
           >
             로그인
           </LoginButton>

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled, { ThemeProvider } from 'styled-components';
 import theme from '../styles/theme';
-// import SmallButton from '../components/Button/SmallButton';
+import Button from '../components/Button/Button';
 
 const Container = styled.div`
   display: flex;
@@ -14,7 +14,7 @@ const Container = styled.div`
 const StyledTitle = styled.div`
   width: 53%;
   height: 76px;
-  margin: 297px 24% 126px 24%;
+  margin: 297px 24% 126px 24%; /* Adjusted margin */
   font-family: ${theme.font.family.pretendard_regular};
   font-weight: 700;
   font-size: 64px;
@@ -23,43 +23,58 @@ const StyledTitle = styled.div`
   text-align: center;
 `;
 
-/* const ButtonWrapper = styled.div`
+const ButtonWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-`; */
+  width: 100%;
+  gap: 15px;
+`;
 
+const SignupButton = styled(Button)`
+  width: 100%; /* Adjusted width */
+  margin-top: 126px;
+`;
 
-/* const StyledButton = styled.button`
-  width: 85%;
-  height: 76px;
-  background-color: ${props => (props.primary ? '#00DDA8' : '#333333')};
-  color: ${props => (props.primary ? '#000000' : '#7f7f7f')};
-  font-family: ${props => props.theme.font.family.pretendard_semiBold};
-  font-size: 24px;
-  font-weight: 700;
-  margin-top: 20px;
-  border: none;
-  border-radius: 8px;
-  cursor: pointer;
-
-  &:hover {
-    opacity: 0.9;
-  }
-`; */
+const LoginButton = styled(Button)`
+  width: 100%; /* Adjusted width */
+`;
 
 const Login = () => {
+  const [signupClicked, setSignupClicked] = useState(false);
+  const [loginClicked, setLoginClicked] = useState(false);
+
+  const handleSignupClick = () => {
+    setSignupClicked(!signupClicked);
+  };
+
+  const handleLoginClick = () => {
+    setLoginClicked(!loginClicked);
+  };
+
   return (
     <ThemeProvider theme={theme}>
       <Container>
         <StyledTitle>Weeth</StyledTitle>
-        
+        <ButtonWrapper>
+          <SignupButton
+            color={signupClicked ? "#0E9871" : theme.color.main.mainColor}
+            textColor={signupClicked ? "#097154" : theme.color.grayScale.white} /* Temporary colors */
+            onClick={handleSignupClick}
+          >
+            회원가입
+          </SignupButton>
+          <LoginButton
+            color={loginClicked ? theme.color.grayScale.gray20 : theme.color.grayScale.gray30} /* Adjusted conditional logic */
+            textColor={loginClicked ? theme.color.grayScale.gray12 : theme.color.grayScale.white} /* Temporary colors */
+            onClick={handleLoginClick}
+          >
+            로그인
+          </LoginButton>
+        </ButtonWrapper>
       </Container>
     </ThemeProvider>
   );
 };
 
 export default Login;
-
-/* <SmallButton color="#00DDA8" textColor="#000000" width="197px" height="76px">회원가입</SmallButton>
-          <SmallButton color="#333333" textColor="#7f7f7f" width="197px" height="76px">로그인</SmallButton> */

--- a/src/pages/Signin.jsx
+++ b/src/pages/Signin.jsx
@@ -1,0 +1,5 @@
+const Signin = () => {
+  return 'Signin';
+};
+
+export default Signin;


### PR DESCRIPTION
## 1. 개발 내용
Weeth 초기 화면 페이지의 css 작업 완료

## 2. 구현 세부사항

![image](https://github.com/user-attachments/assets/2e5111b9-d6f3-4aa2-a602-2667e6d15195)


- [x] Weeth 커다란 로고 UI 만들기
<img width="129" alt="weeth로고" src="https://github.com/user-attachments/assets/d2bade3c-4fc4-4f8e-8d41-e62e1723213a">


- [x] 각각의 회원가입, 로그인 버튼 만들기
<img width="149" alt="image" src="https://github.com/user-attachments/assets/0e1ffde7-058f-4aa1-8e40-7318dd3cd668">

- [x] 페이지 라우팅 구현하기
회원가입 버튼을 누를 시 signup 페이지(회원가입 페이지)
로그인 버튼을 누를 시 signin 페이지(로그인 페이지)
로 이동할 수 있게 하였다.

## 3. 메모

- 이상하게 npm start로 처음에 들어가면 규격이 안 맞을 때도 있었다.. 

