### PR TITLE
#57 design: 출석 조회 페이지 css 설정

### DIFF
--- a/src/components/Attendance/AttendCheckMain.jsx
+++ b/src/components/Attendance/AttendCheckMain.jsx
@@ -101,6 +101,7 @@ const MeetingTitle = styled.div`
   flex-direction: row;
   margin-left: 2%;
   font-size: 16px;
+  font-family: ${theme.font.family.pretendard_semiBold};
 `;
 const MeetingInfo = styled.div`
   display: flex;
@@ -109,6 +110,9 @@ const MeetingInfo = styled.div`
   margin-left: 5%;
   font-size: 14px;
   line-height: 1.7;
+`;
+const StyledText = styled.div`
+  margin-top: -2.5px;
 `;
 
 const SmallBox = ({ title, num }) => {
@@ -162,7 +166,8 @@ const AttendCheckMain = () => {
     <Container>
       <Header>
         <SemiTitle>
-          <SemiBold>김위드</SemiBold> 님의 출석횟수
+          <SemiBold>김위드</SemiBold>
+          <StyledText>&nbsp;님의 출석횟수</StyledText>
         </SemiTitle>
         <Penalty>
           <SemiBold>3회</SemiBold>

--- a/src/components/Attendance/AttendCheckMain.jsx
+++ b/src/components/Attendance/AttendCheckMain.jsx
@@ -1,100 +1,208 @@
 import styled from 'styled-components';
+import PropTypes from 'prop-types';
 import theme from '../../styles/theme';
 import Caption from '../Caption';
 
 const Container = styled.div`
   display: flex;
   flex-direction: column;
-  align-items: center;
   width: 100%;
-  font-family: ${theme.font.family.pretendard_semiBold};
+  font-family: ${theme.font.family.pretendard_regular};
   color: ${theme.color.grayScale.white};
+`;
+
+const Header = styled.div`
+  margin-left: 8%;
+`;
+
+const SemiTitle = styled.div`
+  display: flex;
+  flex-direction: row;
+  margin-top: 25px;
+  font-size: 16px;
+`;
+
+const Penalty = styled.div`
+  margin-top: 19px;
+  font-size: 32px;
+`;
+
+const SemiBold = styled.div`
+  font-family: ${theme.font.family.pretendard_semiBold};
+  include-font-padding: false;
+  display: flex;
+  flex-direction: row;
 `;
 
 const StyledBox = styled.div`
   background-color: ${theme.color.grayScale.gray18};
   border-radius: 10px;
-  padding: 4%;
-  margin: 10px 0;
+  margin: 26px 4% 0 4%;
   display: flex;
   flex-direction: column;
-  align-items: start;
-  width: 90%;
+  align-items: center;
+  width: 92%;
 `;
 
 const SmallStyledBoxContainer = styled.div`
   display: flex;
   justify-content: space-between;
-  width: 100%;
-  margin-bottom: 20px;
+  width: 92%;
+  margin: 15px 4% 0 4%;
 `;
 
 const SmallStyledBox = styled.div`
-  background-color: ${theme.color.grayScale.gray20};
+  background-color: ${theme.color.grayScale.gray30};
   border-radius: 10px;
-  padding: 10px;
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: 30%;
+  width: 95px;
+  height: 93px;
   text-align: center;
-  margin: 0 2%; /* 각 박스 사이의 간격을 4%로 설정 (양쪽에 2%씩) */
-  box-sizing: border-box; /* 박스 사이즈를 포함하여 간격을 조절 */
+`;
+
+const SmallBoxTitle = styled.div`
+  margin-top: 15px;
+  font-size: 14px;
+`;
+
+const SmallBoxNum = styled.div`
+  margin-top: 20px;
+  font-size: 18px;
+  font-family: ${theme.font.family.pretendard_semiBold};
+`;
+
+const Line = styled.div`
+  width: 94%;
+  height: 1px;
+  background-color: ${theme.color.grayScale.gray30};
+  margin: 30px 3% 0 3%;
 `;
 
 const MeetingInfoBox = styled.div`
   background-color: ${theme.color.grayScale.gray18};
   border-radius: 10px;
-  padding: 15px;
-  margin: 10px 0;
+  margin: 20px 0;
   display: flex;
   flex-direction: column;
   align-items: start;
+  width: 100%;
 `;
+
+const MeetingHeader = styled.div`
+  display: flex;
+  flex-direction: row;
+  margin-left: 5%;
+  width: 95%;
+`;
+const MeetingTitle = styled.div`
+  display: flex;
+  flex-direction: row;
+  margin-left: 2%;
+  font-size: 16px;
+`;
+const MeetingInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-top: 15px;
+  margin-left: 5%;
+  font-size: 14px;
+  line-height: 1.7;
+`;
+
+const SmallBox = ({ title, num }) => {
+  return (
+    <SmallStyledBox>
+      <SmallBoxTitle>{title}</SmallBoxTitle>
+      <SmallBoxNum>{num}</SmallBoxNum>
+    </SmallStyledBox>
+  );
+};
+
+const MeetingBox = ({ attend, title, week, date, place }) => {
+  return (
+    <MeetingInfoBox>
+      <MeetingHeader>
+        {attend ? (
+          <Caption color={theme.color.main.mainColor}>출석</Caption>
+        ) : (
+          <Caption color={theme.color.main.negative}>결석</Caption>
+        )}
+        <MeetingTitle>
+          {week}: {title}
+        </MeetingTitle>
+      </MeetingHeader>
+      <MeetingInfo>
+        <div>
+          날짜: {date}
+          <br />
+          장소: {place}
+        </div>
+      </MeetingInfo>
+    </MeetingInfoBox>
+  );
+};
+
+SmallBox.propTypes = {
+  title: PropTypes.string.isRequired,
+  num: PropTypes.string.isRequired,
+};
+
+MeetingBox.propTypes = {
+  attend: PropTypes.bool.isRequired,
+  title: PropTypes.string.isRequired,
+  week: PropTypes.string.isRequired,
+  date: PropTypes.string.isRequired,
+  place: PropTypes.string.isRequired,
+};
 
 const AttendCheckMain = () => {
   return (
     <Container>
-      <div>김위드 님의 출석횟수</div>
-      <div>3회</div>
+      <Header>
+        <SemiTitle>
+          <SemiBold>김위드</SemiBold> 님의 출석횟수
+        </SemiTitle>
+        <Penalty>
+          <SemiBold>3회</SemiBold>
+        </Penalty>
+      </Header>
       <StyledBox>
         <SmallStyledBoxContainer>
-          <SmallStyledBox>
-            <div>정기모임</div>
-            <div>8회</div>
-          </SmallStyledBox>
-          <SmallStyledBox>
-            <div>출석</div>
-            <div>3회</div>
-          </SmallStyledBox>
-          <SmallStyledBox>
-            <div>결석</div>
-            <div>1회</div>
-          </SmallStyledBox>
+          <SmallBox title="정기 모임" num="8회" />
+          <SmallBox title="출석" num="3회" />
+          <SmallBox title="결석" num="1회" />
         </SmallStyledBoxContainer>
+        <Line />
         <MeetingInfoBox>
-          <Caption />
-          <div>1주차: 개강총회</div>
-          <div>날짜: 2024년 7월 18일 (19:00 - 20:30)</div>
-          <div>장소: 가천관 247호</div>
-        </MeetingInfoBox>
-        <MeetingInfoBox>
-          <Caption />
-          <div>2주차: 미션1 시작</div>
-          <div>날짜: 2024년 7월 25일 (19:00 - 20:30)</div>
-          <div>장소: 가천관 247호</div>
-        </MeetingInfoBox>
-        <MeetingInfoBox>
-          <Caption />
-          <div>3주차: 미션2 시작</div>
-          <div>날짜: 2024년 8월 1일 (19:00 - 20:30)</div>
-          <div>장소: 가천관 247호</div>
-        </MeetingInfoBox>
-        <MeetingInfoBox>
-          <Caption />
-          <div>4주차: 미션3 시작</div>
-          <div>날짜: 2024년 8월 8일 (19:00 - 20:30)</div>
-          <div>장소: 가천관 247호</div>
+          <MeetingBox
+            attend
+            title="개강총회"
+            week="1주차"
+            date="2024년 7월 18일 19:00 - 20:30"
+            place="가천관 247호"
+          />
+          <MeetingBox
+            title="개강총회"
+            week="2주차"
+            date="2024년 7월 19일 19:00 - 20:30"
+            place="가천관 247호"
+          />
+          <MeetingBox
+            attend
+            title="개강총회"
+            week="3주차"
+            date="2024년 7월 20일 19:00 - 20:30"
+            place="가천관 247호"
+          />
+          <MeetingBox
+            attend
+            title="개강총회"
+            week="4주차"
+            date="2024년 7월 21일 19:00 - 20:30"
+            place="가천관 247호"
+          />
         </MeetingInfoBox>
       </StyledBox>
     </Container>

--- a/src/components/Caption.jsx
+++ b/src/components/Caption.jsx
@@ -6,7 +6,7 @@ import theme from '../styles/theme';
 // props 전달 없으면 gray30에 흰색 글씨로 기본형 버튼
 
 const BasicCaption = styled.button`
-  width: 49px;
+  width: 47px;
   height: 19px;
   background-color: ${({ color }) => color || theme.color.grayScale.gray30};
   font-family: ${theme.font.family.pretendard_semiBold};
@@ -14,18 +14,16 @@ const BasicCaption = styled.button`
   border: none;
   border-radius: 30px;
   cursor: pointer;
-  font-size: 16px;
+  font-size: 12px;
   display: flex;
   align-items: center;
   justify-content: center;
 `;
 
 const Caption = ({ children, color, textColor }) => (
-  <ThemeProvider theme={theme}>
-    <BasicCaption color={color} textColor={textColor}>
-      {children}
-    </BasicCaption>
-  </ThemeProvider>
+  <BasicCaption color={color} textColor={textColor}>
+    {children}
+  </BasicCaption>
 );
 
 export default Caption;

--- a/src/components/home/HomeMain.jsx
+++ b/src/components/home/HomeMain.jsx
@@ -43,6 +43,7 @@ const GridItem = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  cursor: pointer;
 `;
 
 const CalendarItem = styled(GridItem)`


### PR DESCRIPTION
## 1. 개발 내용
출석 조회 페이지 css 설정

## 2. 구현 세부사항
- [x] 폰트 적용
- [x] 간격 조정
- [x] 캡션 스타일 조정
attend라는 bool 타입의 변수를 props로 받아와 출석인지 결석인지 조건부로 렌더링
![image](https://github.com/user-attachments/assets/cbf1e6c2-e7d4-4dee-aee1-29c9d55fa9d1)


## 3. 메모
출석 List에 필요할 거 같은 data
```
  attend: PropTypes.bool.isRequired,
  title: PropTypes.string.isRequired,
  week: PropTypes.string.isRequired,
  date: PropTypes.string.isRequired,
  place: PropTypes.string.isRequired,
```
중간 중간 커밋해야지 되는데 귀찮아서 작업 다 하고 커밋 한 번으로 퉁친다..
담부터는 고치도록 하겟습니다..

+아 그리고 홈에 그리드 아이템 커서 효과가 없어져서 추가햇어요