### PR TITLE
[feat] 뒤로가기 추가

### DIFF
--- a/src/components/Attendance/AttendHeader.jsx
+++ b/src/components/Attendance/AttendHeader.jsx
@@ -27,8 +27,7 @@ const TitleWrapper = styled.div`
 `;
 
 /*
-LeftButton은 모든 페이지에서 동일하게 사용되어
-onClick 외에 다른 props를 설정하지 않았음
+LeftButton은 모든 페이지에서 동일하게 사용되어 다른 props를 설정하지 않았음
 
 RightButton(⋮)과 Text버튼(글자 입력 가능) 중 한가지만 선택하여 사용
 두개의 버튼 모두 onClick 함수를 props로 받습니다
@@ -45,17 +44,13 @@ onClick은 아래 함수에 각각의 함수를 작성
 @@@@안 하면 에러남@@@@
 */
 
-// 뒤로가기
-const onClickLeftButton = () => {
-  window.history.back();
-};
 // const onClickRightButton = () => {};
 // const onClickTextButton = () => {};
 
 const AttendHeader = () => {
   return (
     <StyledAttendHeader>
-      <LeftButton onClick={onClickLeftButton} />
+      <LeftButton />
       <TitleWrapper>
         <Title text="출석" />
       </TitleWrapper>

--- a/src/components/BoardTitle.jsx
+++ b/src/components/BoardTitle.jsx
@@ -21,8 +21,7 @@ const Detail = styled.div`
 `;
 
 /*
-LeftButton은 모든 페이지에서 동일하게 사용되어
-onClick 외에 다른 props를 설정하지 않았음
+LeftButton은 모든 페이지에서 동일하게 사용되어 다른 props를 설정하지 않았음
 
 IndexButton(⋮)과 Text버튼(글자 입력 가능) 중 한가지만 선택하여 사용
 두개의 버튼 모두 onClick 함수를 props로 받습니다
@@ -39,14 +38,13 @@ onClick은 아래 함수에 각각의 함수를 작성
 @@@@안 하면 에러남@@@@
 */
 
-const onClickLeftButton = () => {};
 const onClickIndexButton = () => {};
 
 const BoardTitle = () => {
   return (
     <StyledTitle>
       <StyledHeader>
-        <LeftButton onClick={onClickLeftButton} />
+        <LeftButton />
         <IndexButton onClick={onClickIndexButton} />
       </StyledHeader>
       <h2>중간 발표</h2>

--- a/src/components/Calendar/CalendarHeader.jsx
+++ b/src/components/Calendar/CalendarHeader.jsx
@@ -62,7 +62,7 @@ const ButttonWrapper = styled.div`
 const modalStyles = {
   overlay: {
     backgroundColor: 'rgba(31,31,31,0.5)',
-    backdropFilter: 'blur(2px)',
+    backdropFilter: 'blur(5px)',
     zIndex: 1000,
     width: '100%',
     height: '100%',
@@ -75,7 +75,6 @@ const modalStyles = {
   },
 };
 
-const onClickLeftButton = () => {};
 const onClickIndexButton = () => {};
 
 const CalendarHeader = ({ todayMonth, todayYear, isYear }) => {
@@ -94,7 +93,7 @@ const CalendarHeader = ({ todayMonth, todayYear, isYear }) => {
 
   return (
     <StyledHeader>
-      <LeftButton onClick={onClickLeftButton} />
+      <LeftButton />
       <TitleWrapper>
         <TitleYear>{todayYear}년</TitleYear>
         <TitleMonth>{isYear ? null : `${todayMonth}월`}</TitleMonth>

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -23,8 +23,7 @@ const TitleWrapper = styled.div`
 `;
 
 /*
-LeftButton은 모든 페이지에서 동일하게 사용되어
-onClick 외에 다른 props를 설정하지 않았음
+LeftButton은 모든 페이지에서 동일하게 사용되어 props를 설정하지 않았음
 
 IndexButton(⋮)과 Text버튼(글자 입력 가능) 중 한가지만 선택하여 사용
 두개의 버튼 모두 onClick 함수를 props로 받습니다
@@ -41,14 +40,13 @@ onClick은 아래 함수에 각각의 함수를 작성
 @@@@안 하면 에러남@@@@
 */
 
-const onClickLeftButton = () => {};
 const onClickIndexButton = () => {};
 const onClickTextButton = () => {};
 
 const Header = () => {
   return (
     <StyledHeader>
-      <LeftButton onClick={onClickLeftButton} />
+      <LeftButton />
       <TitleWrapper>
         <Title text="게시판" />
       </TitleWrapper>

--- a/src/components/Header/LeftButton.jsx
+++ b/src/components/Header/LeftButton.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import PropTypes from 'prop-types';
+import { useNavigate } from 'react-router-dom';
 
 import prev from '../../assets/images/Frame 45.png';
 
@@ -10,16 +10,18 @@ const ImgButton = styled.div`
   cursor: pointer;
 `;
 
-const LeftButton = ({ onClick }) => {
+const LeftButton = () => {
+  const navi = useNavigate();
+
   return (
-    <ImgButton onClick={onClick}>
+    <ImgButton
+      onClick={() => {
+        navi(-1);
+      }}
+    >
       <img src={prev} alt="prev" />
     </ImgButton>
   );
-};
-
-LeftButton.propTypes = {
-  onClick: PropTypes.func.isRequired,
 };
 
 export default LeftButton;

--- a/src/components/Member/MemberHeader.jsx
+++ b/src/components/Member/MemberHeader.jsx
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import { useNavigate } from 'react-router-dom';
 
 import LeftButton from '../Header/LeftButton';
 import Title from '../Header/Title';
@@ -16,19 +15,10 @@ const TitleWrapper = styled.div`
   transform: translateX(-50%);
 `;
 
-// //  해당 함수에 온클릭 이벤트 작성
-// const onClickLeftButton = () => {};
-
 const UserHeader = () => {
-  const navi = useNavigate();
-
   return (
     <StyledHeader>
-      <LeftButton
-        onClick={() => {
-          navi(-1);
-        }}
-      />
+      <LeftButton />
       <TitleWrapper>
         <Title text="멤버" />
       </TitleWrapper>

--- a/src/components/MyPage/MyPageHeader.jsx
+++ b/src/components/MyPage/MyPageHeader.jsx
@@ -1,6 +1,5 @@
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
-import { useNavigate } from 'react-router-dom';
 
 import LeftButton from '../Header/LeftButton';
 import Title from '../Header/Title';
@@ -22,15 +21,9 @@ const TitleWrapper = styled.div`
 `;
 
 const MyPageHeader = ({ isEdit }) => {
-  const navi = useNavigate();
-
   return (
     <StyledHeader>
-      <LeftButton
-        onClick={() => {
-          navi(-1);
-        }}
-      />
+      <LeftButton />
       <TitleWrapper>
         <Title text="My" />
       </TitleWrapper>


### PR DESCRIPTION
## 1. 개발 내용
뒤로가기 기능 추가

## 2. 구현 세부사항
- LeftButton이 모든 페이지에서 동일하게 뒤로가기로 사용되어 props를 제거하고 컴포넌트 자체에 기능을 추가하였음

## 3. 메모
출석 페이지에는 뒤로가기가 `window.history.back();`로 구현되어 있었는데, 리액트 앱 구조에서는 `useNavigate(-1)`를 이용하는 것이 권장된다고 함.
그래서 useNavigate를 이용했습니다~