### PR TITLE
#97 fix: 출석 이름 가져올 때 에러 로직 수정

### DIFF
--- a/src/components/Attendance/AttendMain.jsx
+++ b/src/components/Attendance/AttendMain.jsx
@@ -98,12 +98,13 @@ const AttendMain = () => {
 
   const { userData, error } = useContext(UserContext);
 
+  let userName;
   if (error) {
-    return <div>Error: {error}</div>;
-  }
-
-  if (!userData) {
-    return <div>Loading...</div>;
+    userName = 'error';
+  } else if (!userData) {
+    userName = 'loading';
+  } else {
+    userName = userData.name;
   }
 
   // 일단 일정 있고 패널티 있는 게 true
@@ -122,7 +123,7 @@ const AttendMain = () => {
     <StyledAttend>
       <div className="name-container">
         <SemiBold>
-          <div className="attend-name">{userData.name}&nbsp;</div>
+          <div className="attend-name">{userName}&nbsp;</div>
         </SemiBold>
         <div className="attend-text">님의 출석률은</div>
       </div>


### PR DESCRIPTION
## 설명
users api에서 이름 가져올 때 에러나면 출석 페이지 전체 컴포넌트가 안 보였는데 이름에 해당하는 부분에만 에러처리 되도록 수정