### PR TITLE
#77 feat: member api 연결

### DIFF
--- a/src/components/Member/Category.jsx
+++ b/src/components/Member/Category.jsx
@@ -24,25 +24,25 @@ const Button = styled.button`
 `;
 
 const Category = ({ setSelectedCardinal }) => {
-  const [selectedCategory, setSelectedCategory] = useState('all');
+  const [selectedCategory, setSelectedCategory] = useState(0);
 
   const onClickAll = () => {
-    setSelectedCategory('all');
-    setSelectedCardinal(null);
+    setSelectedCategory(0);
+    setSelectedCardinal(0);
   };
 
   const onClick1 = () => {
-    setSelectedCategory('1');
+    setSelectedCategory(1);
     setSelectedCardinal(1);
   };
 
   const onClick2 = () => {
-    setSelectedCategory('2');
+    setSelectedCategory(2);
     setSelectedCardinal(2);
   };
 
   const onClick3 = () => {
-    setSelectedCategory('3');
+    setSelectedCategory(3);
     setSelectedCardinal(3);
   };
 
@@ -50,30 +50,18 @@ const Category = ({ setSelectedCardinal }) => {
     <StyledCategory>
       <Button
         type="button"
-        checked={selectedCategory === 'all'}
+        checked={selectedCategory === 0}
         onClick={onClickAll}
       >
         전체
       </Button>
-      <Button
-        type="button"
-        checked={selectedCategory === '1'}
-        onClick={onClick1}
-      >
+      <Button type="button" checked={selectedCategory === 1} onClick={onClick1}>
         1기
       </Button>
-      <Button
-        type="button"
-        checked={selectedCategory === '2'}
-        onClick={onClick2}
-      >
+      <Button type="button" checked={selectedCategory === 2} onClick={onClick2}>
         2기
       </Button>
-      <Button
-        type="button"
-        checked={selectedCategory === '3'}
-        onClick={onClick3}
-      >
+      <Button type="button" checked={selectedCategory === 3} onClick={onClick3}>
         3기
       </Button>
     </StyledCategory>
@@ -81,7 +69,7 @@ const Category = ({ setSelectedCardinal }) => {
 };
 
 Category.propTypes = {
-  setSelectedCardinal: PropTypes.string.isRequired,
+  setSelectedCardinal: PropTypes.number.isRequired,
 };
 
 export default Category;

--- a/src/components/Member/InfoComponent.jsx
+++ b/src/components/Member/InfoComponent.jsx
@@ -27,8 +27,6 @@ const MainColor = styled.div`
 `;
 
 const InfoComponent = ({ src, alt, index, value }) => {
-  let isPosition = false;
-  if (index === 'position') isPosition = true;
   let positionKo = 'none';
 
   switch (value) {
@@ -48,21 +46,28 @@ const InfoComponent = ({ src, alt, index, value }) => {
       positionKo = '없음';
   }
 
+  const renderValue = () => {
+    if (index === '역할') {
+      return positionKo;
+    }
+    if (index === '기수') {
+      console.log({ value });
+      return value;
+    }
+    return value;
+  };
+
   return (
-    <>
+    <div>
       <Info>
         <img src={src} alt={alt} />
         <Text>
           <div>{index}</div>
-          {isPosition ? (
-            <MainColor>{positionKo}</MainColor>
-          ) : (
-            <MainColor>{value}</MainColor>
-          )}
+          <MainColor>{renderValue()}</MainColor>
         </Text>
       </Info>
       <Line />
-    </>
+    </div>
   );
 };
 
@@ -70,7 +75,11 @@ InfoComponent.propTypes = {
   src: PropTypes.string.isRequired,
   alt: PropTypes.string.isRequired,
   index: PropTypes.string.isRequired,
-  value: PropTypes.string.isRequired,
+  value: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.arrayOf(PropTypes.number),
+  ]).isRequired,
 };
 
 export default InfoComponent;

--- a/src/hooks/UserAPI.jsx
+++ b/src/hooks/UserAPI.jsx
@@ -33,7 +33,7 @@ userData.name 이런식으로 data 사용하면 됩니당!!
 */
 
 const UserAPI = () => {
-  const { setUserData, setError } = useContext(UserContext);
+  const { setUserData, setError, setAllUserData } = useContext(UserContext);
 
   const ACCESS_TOKEN = process.env.REACT_APP_ACCESS_TOKEN;
 
@@ -45,6 +45,7 @@ const UserAPI = () => {
       Authorization: `Bearer ${ACCESS_TOKEN}`,
     };
 
+    // 내 정보 조회
     axios
       .get('http://13.125.78.31:8080/users', { headers })
       .then((response) => {
@@ -57,9 +58,23 @@ const UserAPI = () => {
       .catch((err) => {
         setError('An error occurred while fetching the data');
       });
-  }, [ACCESS_TOKEN, setUserData, setError]);
 
-  return null; 
+      // 모든 멤버 조회
+      axios.get('http://13.125.78.31:8080/users/all', { headers })
+      .then((response) => {
+        if (response.data.code === 200) {
+          setAllUserData(response.data.data);
+        } else {
+          setError(response.data.message);
+        }
+      })
+      .catch((err) => {
+        setError('An error occurred while fetching the all users data');
+      });
+
+  }, [ACCESS_TOKEN, setUserData, setError, setAllUserData]);
+
+  return null;
 };
 
 export default UserAPI;

--- a/src/hooks/UserContext.js
+++ b/src/hooks/UserContext.js
@@ -6,10 +6,11 @@ export const UserContext = createContext();
 // Provider 컴포넌트
 export const UserProvider = ({ children }) => {
   const [userData, setUserData] = useState(null);
+  const [allUserData, setAllUserData] = useState(null);
   const [error, setError] = useState(null);
 
   return (
-    <UserContext.Provider value={{ userData, setUserData, error, setError }}>
+    <UserContext.Provider value={{ userData, setUserData, allUserData, setAllUserData, error, setError }}>
       {children}
     </UserContext.Provider>
   );

--- a/src/pages/Edit.jsx
+++ b/src/pages/Edit.jsx
@@ -1,9 +1,11 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import styled from 'styled-components';
 
 import MyPageHeader from '../components/MyPage/MyPageHeader';
 import InfoInput from '../components/MyPage/InfoInput';
-import mockUser from '../components/mockData/mockUser';
+// import mockUser from '../components/mockData/mockUser';
+
+import { UserContext } from '../hooks/UserContext';
 
 const StyledEdit = styled.div`
   width: 370px;
@@ -20,55 +22,63 @@ const NoEdit = styled.div`
 `;
 
 const Edit = () => {
-  const [userInfo, setUserInfo] = useState(mockUser[0]);
+  const [userInfo, setUserInfo] = useState(UserContext);
+  const { userData, error } = useContext(UserContext);
 
+  if (error) {
+    return <div>Error: {error}</div>;
+  }
+
+  if (!userData) {
+    return <div>Loading...</div>;
+  }
   const editValue = (key, value) => {
     setUserInfo({ ...userInfo, [key]: value });
   };
 
-  const saveEditInfo = () => {
-    mockUser[0] = userInfo;
-  };
+  // const saveEditInfo = () => {
+  //   userData = userInfo;
+  // };
 
   return (
     <StyledEdit>
-      <MyPageHeader isEdit saveEditInfo={saveEditInfo} />
+      <MyPageHeader isEdit />
       <InfoWrapper>
         <InfoInput
           text="이름"
-          origValue={mockUser[0].name}
+          origValue={userData.name}
           editValue={(value) => editValue('name', value)}
         />
         <InfoInput
           text="학번"
-          origValue={mockUser[0].studentId}
+          origValue={userData.studentId}
           editValue={(value) => editValue('studentId', value)}
         />
         <InfoInput
           text="학과"
-          origValue={mockUser[0].department}
+          origValue={userData.department}
           editValue={(value) => editValue('department', value)}
         />
         <InfoInput
           text="핸드폰"
-          origValue={mockUser[0].tel}
+          origValue={userData.tel}
           editValue={(value) => editValue('tel', value)}
         />
         <NoEdit>
           <InfoInput
             text="기수"
-            origValue={mockUser[0].cardinal}
+            origValue={userData.cardinal}
             editValue={(value) => editValue('cardinal', value)}
           />
         </NoEdit>
         <InfoInput
           text="역할"
-          origValue={mockUser[0].position}
+          origValue={userData.position}
           editValue={(value) => editValue('position', value)}
         />
         <InfoInput
           text="메일"
-          origValue={mockUser[0].email}
+          origValue={userData.email}
           editValue={(value) => editValue('email', value)}
         />
       </InfoWrapper>

--- a/src/pages/Member.jsx
+++ b/src/pages/Member.jsx
@@ -1,11 +1,12 @@
 import styled from 'styled-components';
-import { useState } from 'react';
+import { useState, useContext } from 'react';
 
 import theme from '../styles/theme';
 import MemberHeader from '../components/Member/MemberHeader';
 import Category from '../components/Member/Category';
 import MemberName from '../components/Member/MemberName';
-import mockUser from '../components/mockData/mockUser';
+// import mockUser from '../components/mockData/mockUser';
+import { UserContext } from '../hooks/UserContext';
 
 const StyledMember = styled.div`
   width: 370px;
@@ -28,12 +29,18 @@ const MemberList = styled.div`
 `;
 
 const Member = () => {
-  const [selectedCardinal, setSelectedCardinal] = useState(null);
+  const [selectedCardinal, setSelectedCardinal] = useState(0);
 
-  const filteredUsers =
-    selectedCardinal === null
-      ? mockUser
-      : mockUser.filter((user) => user.cardinal === selectedCardinal);
+  const { allUserData, error } = useContext(UserContext);
+
+  if (error) {
+    return <div>Error: {error}</div>;
+  }
+
+  if (!allUserData) {
+    return <div>Loading...</div>;
+  }
+  console.log(allUserData);
 
   return (
     <StyledMember>
@@ -42,14 +49,15 @@ const Member = () => {
         <Category setSelectedCardinal={setSelectedCardinal} />
       </CategoryWrapper>
       <MemberList>
-        {filteredUsers.map((user) => (
+        <MemberName />
+        {allUserData[selectedCardinal].map((user) => (
           <MemberName
-            key={user.name}
+            key={user.studentId}
             name={user.name}
             studentId={user.studentId}
             department={user.department}
             email={user.email}
-            cardinal={user.cardinal}
+            cardinal={user.cardinals}
             position={user.position}
           />
         ))}

--- a/src/pages/Member.jsx
+++ b/src/pages/Member.jsx
@@ -23,9 +23,16 @@ const MemberList = styled.div`
   border-top-left-radius: 20px;
   border-top-right-radius: 20px;
   height: 100%;
-  max-width: 350px;
+  width: 350px;
   margin: 0px 10px auto;
   padding-bottom: 183px;
+`;
+
+const Error = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-top: 20px;
+  font-family: ${theme.font.family.pretendard_semiBold};
 `;
 
 const Member = () => {
@@ -33,14 +40,11 @@ const Member = () => {
 
   const { allUserData, error } = useContext(UserContext);
 
-  if (error) {
-    return <div>Error: {error}</div>;
-  }
-
-  if (!allUserData) {
-    return <div>Loading...</div>;
-  }
-  console.log(allUserData);
+  /*
+  error라면 빈 배열 반환
+  혹은 데이터의 값이 유효하지 않다면 빈 배열 반환
+  */
+  const isValid = error ? [] : allUserData?.[selectedCardinal] || [];
 
   return (
     <StyledMember>
@@ -49,18 +53,25 @@ const Member = () => {
         <Category setSelectedCardinal={setSelectedCardinal} />
       </CategoryWrapper>
       <MemberList>
-        <MemberName />
-        {allUserData[selectedCardinal].map((user) => (
-          <MemberName
-            key={user.studentId}
-            name={user.name}
-            studentId={user.studentId}
-            department={user.department}
-            email={user.email}
-            cardinal={user.cardinals}
-            position={user.position}
-          />
-        ))}
+        {/* isValid가 빈배열인가?(==error?)
+        true: MemberName 렌더링
+        false: ERROR
+        */}
+        {isValid.length > 0 ? (
+          isValid.map((user) => (
+            <MemberName
+              key={user.studentId}
+              name={user.name}
+              studentId={user.studentId}
+              department={user.department}
+              email={user.email}
+              cardinal={user.cardinals}
+              position={user.position}
+            />
+          ))
+        ) : (
+          <Error>ERROR</Error>
+        )}
       </MemberList>
     </StyledMember>
   );

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -1,10 +1,11 @@
 import styled from 'styled-components';
 
+import { useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import MyPageHeader from '../components/MyPage/MyPageHeader';
 import InfoComponent from '../components/Member/InfoComponent';
-import mockUser from '../components/mockData/mockUser';
+// import mockUser from '../components/mockData//mockUser';
 
 import icName from '../assets/images/ic_name.svg';
 import icId from '../assets/images/ic_studentID.svg';
@@ -13,8 +14,8 @@ import icCardinal from '../assets/images/ic_cardinal.svg';
 import icPhone from '../assets/images/ic_phone.svg';
 import icPosition from '../assets/images/ic_position.svg';
 import icEmail from '../assets/images/ic_mail.svg';
-
 import icEdit from '../assets/images/ic_edit.svg';
+import { UserContext } from '../hooks/UserContext';
 
 import theme from '../styles/theme';
 
@@ -49,6 +50,16 @@ const NegativeButton = styled.div`
 `;
 
 const MyPage = () => {
+  const { userData, error } = useContext(UserContext);
+
+  if (error) {
+    return <div>Error: {error}</div>;
+  }
+
+  if (!userData) {
+    return <div>Loading...</div>;
+  }
+
   const navi = useNavigate();
   return (
     <StyledDetails>
@@ -58,43 +69,43 @@ const MyPage = () => {
           src={icName}
           alt="smile"
           index="이름"
-          value={mockUser[0].name}
+          value={userData.name}
         />
         <InfoComponent
           src={icId}
           alt="heart"
           index="학번"
-          value={mockUser[0].studentId}
+          value={userData.studentId}
         />
         <InfoComponent
           src={icDepartment}
           alt="pencil"
           index="학과"
-          value={mockUser[0].department}
+          value={userData.department}
         />
         <InfoComponent
           src={icPhone}
           alt="phone"
           index="핸드폰"
-          value={mockUser[0].tel}
+          value={userData.tel}
         />
         <InfoComponent
           src={icCardinal}
           alt="tag"
           index="기수"
-          value={mockUser[0].cardinal}
+          value={userData.cardinal}
         />
         <InfoComponent
           src={icPosition}
           alt="monitor"
           index="역할"
-          value={mockUser[0].position}
+          value={userData.position}
         />
         <InfoComponent
           src={icEmail}
           alt="mail"
           index="메일"
-          value={mockUser[0].email}
+          value={userData.email}
         />
       </InfoWrapper>
       <ImgButton


### PR DESCRIPTION
## 1. 개발 내용
멤버 api 연결

## 2. 구현 세부사항
- 마이페이지 / 개인정보 수정 / 동아리원 조회 연결 완료
- 개인정보 수정 페이지의 경우 기존의 값을 가져오기만 하고, 수정하는 부분은 구현되지 않음
-  에러 시 해당 컴포넌트에 대해서만 에러가 뜨도록 수정했습니당
![스크린샷 2024-07-26 223537](https://github.com/user-attachments/assets/9eae751b-149b-4753-965d-e5b1a5d94364)

## 3. 메모
- 일단 캘린더 GET 연결 다 끝내고 멤버 PATCH(개인정보 수정) / DELETE(탈퇴) 마저 하겠습니당
- 현재 1기/2기 유저 데이터가 없어서 누르면 에러가 뜹니다 ㅜ-ㅜ 데이터가 없는 경우 다른 에러메세지를 나타나게 하는 게 나을지 고민 중....