### PR TITLE
#124 feat: 회비 api 연결

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -29,6 +29,7 @@ import { UserProvider } from './hooks/UserContext';
 import UserAPI from './hooks/UserAPI';
 import { EventProvider } from './hooks/EventContext';
 import EventAPI from './hooks/EventAPI';
+import { DuesProvider } from './hooks/DuesContext';
 
 //user api 받아온 정보 담는 context
 
@@ -37,6 +38,7 @@ function App() {
     <ThemeProvider theme={theme}>
       <UserProvider>
       <EventProvider>
+      <DuesProvider>
       <UserAPI />
       <EventAPI />
         <Routes>
@@ -60,7 +62,8 @@ function App() {
           <Route path="/board" element={<Board />} />
           <Route path="/boardPosting" element={<BoardPosting />} />
         </Routes>
-        </EventProvider>
+      </DuesProvider>
+      </EventProvider>
       </UserProvider>
     </ThemeProvider>
   );

--- a/src/components/Receipt/ReceiptMain.jsx
+++ b/src/components/Receipt/ReceiptMain.jsx
@@ -1,12 +1,15 @@
 import styled from 'styled-components';
+import { useContext } from 'react';
 import theme from '../../styles/theme';
 import ReceiptInfo from './ReceiptInfo';
+import { DuesContext } from '../../hooks/DuesContext';
 
 const StyledReceipt = styled.div`
   width: 370px;
-  height: height: calc(var(--vh, 1vh) * 100);
+  height: calc(var(--vh, 1vh) * 100);
   font-family: ${theme.font.family.pretendard_regular};
 `;
+
 const Line = styled.div`
   border: 1px solid;
   color: #4d4d4d;
@@ -14,6 +17,7 @@ const Line = styled.div`
   margin: 15px 6% 0 6%;
   transform: scaleY(0.2);
 `;
+
 const StyledMonth = styled.div`
   font-family: ${theme.font.family.pretendard_semiBold};
   font-size: 18px;
@@ -36,16 +40,19 @@ const ScrollContainer = styled.div`
   &::-webkit-scrollbar-thumb:hover {
   }
 `;
+
 const GridItem = styled.div`
   flex: 0 0 auto;
   margin-right: 10px;
-  padding: 10px 20px;
+  padding: 0; /* 패딩 제거 */
   background-color: ${theme.color.grayScale.gray18};
   width: 56%;
   height: 124px;
   color: #fff;
   border-radius: 10px;
   display: flex;
+  justify-content: center;
+  align-items: center;
   font-size: 14px;
   white-space: nowrap;
   &:last-child {
@@ -53,24 +60,64 @@ const GridItem = styled.div`
   }
 `;
 
+const GridItemImage = styled.img`
+  width: 100%;
+  height: 100%;
+  border-radius: 10px;
+  object-fit: cover;
+`;
+
 const ReceiptMain = () => {
+  const { duesData } = useContext(DuesContext);
+
+  // 영수증 데이터를 월별로 묶어주기
+  const groupedByMonth = duesData.reduce((acc, curr) => {
+    const month = new Date(curr.date).getMonth() + 1;
+    if (!acc[month]) {
+      acc[month] = [];
+    }
+    acc[month].push(curr);
+    return acc;
+  }, {});
+
+  // 3월 ~ 8월
+  const FirstSemester = [3, 4, 5, 6, 7, 8];
+
   return (
     <StyledReceipt>
-      <StyledMonth>1월</StyledMonth>
-      <Line />
-      <StyledMonth>2월</StyledMonth>
-      <Line />
-      <StyledMonth>3월</StyledMonth>
-      <ReceiptInfo money="234,234원" date="2024. 03." memo="20,000 * 12명" />
-      <ScrollContainer>
-        <GridItem>영수증 사진</GridItem>
-      </ScrollContainer>
-      <ReceiptInfo money="234,234원" date="2024. 03." memo="20,000 * 12명" />
-      <ScrollContainer>
-        <GridItem>영수증 사진</GridItem>
-        <GridItem>영수증 사진</GridItem>
-      </ScrollContainer>
-      <Line />
+      {FirstSemester.map((month) => (
+        <div key={month}>
+          <StyledMonth>{month}월</StyledMonth>
+          {groupedByMonth[month] ? (
+            groupedByMonth[month].map((receipt) => (
+              <div key={receipt.id}>
+                <ReceiptInfo
+                  money={`${receipt.amount.toLocaleString()}원`}
+                  date={new Date(receipt.date).toLocaleDateString('ko-KR')}
+                  memo={receipt.description}
+                />
+                <ScrollContainer>
+                  {receipt.images.length > 0 ? (
+                    receipt.images.map((image, index) => (
+                      <GridItem key={receipt.id}>
+                        <GridItemImage
+                          src={image}
+                          alt={`영수증 사진 ${index + 1}`}
+                        />
+                      </GridItem>
+                    ))
+                  ) : (
+                    <div> </div>
+                  )}
+                </ScrollContainer>
+              </div>
+            ))
+          ) : (
+            <div> </div>
+          )}
+          <Line />
+        </div>
+      ))}
     </StyledReceipt>
   );
 };

--- a/src/components/Receipt/ReceiptMain.jsx
+++ b/src/components/Receipt/ReceiptMain.jsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
+import ReactModal from 'react-modal';
 import theme from '../../styles/theme';
 import ReceiptInfo from './ReceiptInfo';
 import { DuesContext } from '../../hooks/DuesContext';
@@ -55,6 +56,7 @@ const GridItem = styled.div`
   align-items: center;
   font-size: 14px;
   white-space: nowrap;
+  cursor: pointer; /* 커서 추가 */
   &:last-child {
     margin-right: 0;
   }
@@ -67,10 +69,27 @@ const GridItemImage = styled.img`
   object-fit: cover;
 `;
 
+const ModalImage = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+`;
+
 const ReceiptMain = () => {
   const { duesData } = useContext(DuesContext);
+  const [modalIsOpen, setModalIsOpen] = useState(false);
+  const [selectedImage, setSelectedImage] = useState('');
 
-  // 영수증 데이터를 월별로 묶어주기
+  const openModal = (image) => {
+    setSelectedImage(image);
+    setModalIsOpen(true);
+  };
+
+  const closeModal = () => {
+    setModalIsOpen(false);
+    setSelectedImage('');
+  };
+
   const groupedByMonth = duesData.reduce((acc, curr) => {
     const month = new Date(curr.date).getMonth() + 1;
     if (!acc[month]) {
@@ -80,12 +99,11 @@ const ReceiptMain = () => {
     return acc;
   }, {});
 
-  // 3월 ~ 8월
-  const FirstSemester = [3, 4, 5, 6, 7, 8];
+  const months = [3, 4, 5, 6, 7, 8];
 
   return (
     <StyledReceipt>
-      {FirstSemester.map((month) => (
+      {months.map((month) => (
         <div key={month}>
           <StyledMonth>{month}월</StyledMonth>
           {groupedByMonth[month] ? (
@@ -99,7 +117,10 @@ const ReceiptMain = () => {
                 <ScrollContainer>
                   {receipt.images.length > 0 ? (
                     receipt.images.map((image, index) => (
-                      <GridItem key={receipt.id}>
+                      <GridItem
+                        key={receipt.id}
+                        onClick={() => openModal(image)}
+                      >
                         <GridItemImage
                           src={image}
                           alt={`영수증 사진 ${index + 1}`}
@@ -118,6 +139,28 @@ const ReceiptMain = () => {
           <Line />
         </div>
       ))}
+      <ReactModal
+        isOpen={modalIsOpen}
+        onRequestClose={closeModal}
+        style={{
+          overlay: {
+            backgroundColor: 'rgba(0, 0, 0, 0.75)',
+          },
+          content: {
+            top: '50%',
+            left: '50%',
+            right: 'auto',
+            bottom: 'auto',
+            marginRight: '-50%',
+            transform: 'translate(-50%, -50%)',
+            padding: '0',
+            border: 'none',
+            background: 'none',
+          },
+        }}
+      >
+        <ModalImage src={selectedImage} alt="영수증 큰 이미지" />
+      </ReactModal>
     </StyledReceipt>
   );
 };

--- a/src/hooks/DuesContext.js
+++ b/src/hooks/DuesContext.js
@@ -1,0 +1,48 @@
+/* eslint-disable react/jsx-no-constructed-context-values */
+/* eslint-disable react/prop-types */
+// src/contexts/ApiContext.js
+import React, { createContext, useState, useEffect } from 'react';
+import axios from 'axios';
+
+export const DuesContext = createContext();
+
+export const DuesProvider = ({ children }) => {
+  const [duesData, setDuesData] = useState([]);
+  const [totalAmount, setTotalAmount] = useState(0);
+
+  const fetchData = async (cardinal = 3) => {
+    try {
+      const ACCESS_TOKEN = process.env.REACT_APP_ADMIN_TOKEN;
+      const headers = {
+        Authorization: `Bearer ${ACCESS_TOKEN}`,
+      };
+      const response = await axios.get(
+        `http://13.125.78.31:8080/account/${cardinal}`,
+        { headers },
+      );
+      const result = response.data;
+      if (result.code === 200) {
+        setDuesData(result.data.receipts);
+        setTotalAmount(result.data.total);
+        // eslint-disable-next-line no-console
+        console.log('get data:', result.data);
+      } else {
+        // eslint-disable-next-line no-console
+        console.error('Failed to get data:', result.message);
+      }
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Error getting data:', error);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  return (
+    <DuesContext.Provider value={{ duesData, totalAmount, fetchData }}>
+      {children}
+    </DuesContext.Provider>
+  );
+};

--- a/src/pages/Dues.jsx
+++ b/src/pages/Dues.jsx
@@ -1,11 +1,11 @@
 import styled from 'styled-components';
-import { useState } from 'react';
+import { useState, useEffect, useContext } from 'react';
 import theme from '../styles/theme';
 import DuesHeader from '../components/Dues/DuesHeader';
 import DueCategory from '../components/Dues/DueCategory';
 import DuesInfo from '../components/Dues/DuesInfo';
-import mockDues from '../components/mockData/mockDues';
 import DuesTitle from '../components/Dues/DuesTitle';
+import { DuesContext } from '../hooks/DuesContext';
 
 const StyledDues = styled.div`
   width: 370px;
@@ -56,12 +56,17 @@ const MoneyBox = styled.div`
 `;
 
 const Dues = () => {
+  const { duesData, totalAmount, fetchData } = useContext(DuesContext);
   const [selectedCardinal, setSelectedCardinal] = useState(null);
+
+  useEffect(() => {
+    fetchData(selectedCardinal || 3);
+  }, [selectedCardinal, fetchData]);
 
   const filteredDues =
     selectedCardinal === null
-      ? mockDues
-      : mockDues.filter((dues) => dues.cardinal === selectedCardinal);
+      ? duesData
+      : duesData.filter((dues) => dues.cardinal === selectedCardinal);
 
   return (
     <StyledDues>
@@ -72,17 +77,17 @@ const Dues = () => {
       </CategoryWrapper>
       <DuesListBox>
         <MoneyBoxContainer>
-          <MoneyBox>234,234원</MoneyBox>
+          <MoneyBox>{totalAmount.toLocaleString()}원</MoneyBox>
         </MoneyBoxContainer>
         <Line />
         <DuesList>
           {filteredDues.map((dues) => (
             <DuesInfo
               key={dues.id}
-              dues={dues.dues}
+              dues={dues.amount}
               cardinal={dues.cardinal}
               date={dues.date}
-              memo={dues.memo}
+              memo={dues.description}
             />
           ))}
         </DuesList>

--- a/src/pages/Receipt.jsx
+++ b/src/pages/Receipt.jsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import AttendHeader from '../components/Attendance/AttendHeader';
 import ReceiptMain from '../components/Receipt/ReceiptMain';
+import { DuesProvider } from '../hooks/DuesContext';
 
 const Container = styled.div`
   display: flex;
@@ -12,10 +13,12 @@ const Container = styled.div`
 
 const Receipt = () => {
   return (
-    <Container>
-      <AttendHeader text="영수증" />
-      <ReceiptMain />
-    </Container>
+    <DuesProvider>
+      <Container>
+        <AttendHeader text="영수증" />
+        <ReceiptMain />
+      </Container>
+    </DuesProvider>
   );
 };
 


### PR DESCRIPTION
## 설명
회비 api 연결

## 상세설명

- [x] 회비 api에서 데이터 연결
![image](https://github.com/user-attachments/assets/3568cb53-aed7-40bb-bac9-2cefe368578c)

- [x] 영수증 확인
![image](https://github.com/user-attachments/assets/95cea5b7-85f2-41f0-b52f-2617d8a342c2)
![image](https://github.com/user-attachments/assets/2a0eef55-51f1-4c99-ae92-fac81d2455d9)
영수증 사진 누를시 모달창으로 뜨게 변경(디자인팀 컨펌 완료)

- [ ] 수입/ 지출 탭 분리
수입 지출 구분 가능한 data 하나 넣어달라구 말씀 드렸음 단톡에서 말 나온 것처럼 수입이 많지 않은데 굳이 구분이 필요한가에 대해 논의가 필요한 것 같아 정해지면 나중에 수정할 듯

## 메모
App.js에서 헤원이가 수정한 부분이랑 내가 수정한 부분이 충돌나서 그거 해결하고 로그인  페이지 중복 import 해결 했습니다~ 

