### PR TITLE
#127 feat: 로그인 페이지 API 연결 /기능 구현하기(최종)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -10,12 +10,7 @@ index.js
 SmallButton.jsx
 Caption.jsx
 MiddleButton.jsx
-<<<<<<< HEAD
-StudyComponent.jsx
-BoardDetail.jsx
-=======
 DropDown.jsx
->>>>>>> d7b6b0391f93850240277406d8a39b6e0023015a
 
 UserAPI.jsx
 UserContext.js
@@ -25,3 +20,5 @@ BoardAPI.jsx
 BoardContext.js
 
 FileAttachMenu.jsx
+
+Utils.js

--- a/src/hooks/Utils.js
+++ b/src/hooks/Utils.js
@@ -1,0 +1,42 @@
+const Utils = async (response, originalApiFunc, originalParams, navigate) => {
+  // 데이터가 비어있는지 확인(데이터가 null/undefined, 객체, 배열일 때를 확인)
+  const isResponseBodyEmpty = (data) => {
+    if (data === null || data === undefined) return true;
+    if (typeof data === 'object') return Object.keys(data).length === 0;
+    if (Array.isArray(data)) return data.length === 0;
+    return false;
+  };
+
+  if (response.status === 200) {
+    if (!isResponseBodyEmpty(response.data)) {
+      // Body가 안 비어있으면 원래 API 로직
+      return response;
+    } else {
+      // Body가 비어있으면 token, refresh tokens을 local storage에 저장하기
+      const newToken = response.headers['authorization'];
+      const newRefreshToken = response.headers['authorization-refresh'];
+      
+      // 새 토큰, refreshToken 둘 다 있는지
+      if (newToken && newRefreshToken) {
+        localStorage.setItem('accessToken', newToken);
+        localStorage.setItem('refreshToken', newRefreshToken);
+
+        // 새로운 토큰으로 원래의 API 호출을 다시 시도
+        const retryResponse = await originalApiFunc(...originalParams);
+        return retryResponse;
+      } else {
+        throw new Error('새 토큰이 없습니다');
+      }
+    }
+  } else if (response.status === 403) {
+    // local Storage 비우고 로그인 화면으로 리다이렉트
+    localStorage.removeItem('accessToken');
+    localStorage.removeItem('refreshToken');
+    navigate('/login');
+    throw new Error('Forbidden : 로그인 화면으로 리디렉션합니다.');
+  } else {
+    throw new Error(`Unexpected response : ${response.status}`);
+  }
+};
+
+export default Utils;

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,7 +1,5 @@
 import React, { useState } from 'react';
-import React, { useState } from 'react';
 import styled from 'styled-components';
-import axios from 'axios';
 import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
 import LoginHeader from '../components/Login/LoginHeader';
@@ -69,15 +67,9 @@ const Login = () => {
     try {
       const response = await axios.post('http://13.125.78.31:8080/login', params, { withCredentials: true });
 
-      console.log('Response:', response); // 전체 응답을 출력하여 디버깅
-      console.log('Response Headers:', response.header); // 응답 헤더를 출력하여 디버깅
-
       if (response.status === 200) {
-        const token = response.header.get['authorization'];
-        const refreshToken = response.header.get['authorization-refresh'];
-
-        console.log('Access Token:', token);  // 콘솔에 출력하여 확인
-        console.log('Refresh Token:', refreshToken);  // 콘솔에 출력하여 확인
+        const token = response.headers['authorization'];
+        const refreshToken = response.headers['authorization-refresh'];
 
         if (token && refreshToken) {
           localStorage.setItem('accessToken', token);
@@ -87,12 +79,20 @@ const Login = () => {
         } else {
           setError('토큰이 응답에 포함되지 않았습니다.');
         }
-      } else {
-        setError('로그인에 실패했습니다. 다시 시도해주세요.');
       }
     } catch (err) {
       console.error('Error:', err);
-      setError('데이터를 가져오는 중 오류가 발생했습니다.');
+
+      if (err.response) {
+        // 서버가 응답했지만 상태 코드는 2xx 범위 밖
+        setError(err.response.data); // 서버에서 제공하는 오류 메시지를 설정
+      } else if (err.request) {
+        // 요청이 만들어졌지만 응답을 받지 못함
+        setError('서버로부터 응답을 받지 못했습니다.');
+      } else {
+        // 요청을 설정하는 중에 문제가 발생
+        setError('요청을 설정하는 중 오류가 발생했습니다.');
+      }
     }
   };
 
@@ -100,10 +100,10 @@ const Login = () => {
     <Container>
       <LoginHeader isRightButtonEnabled={!!isAllValid} onCompleteClick={handleLogin} />
       <LoginHeaderMargin />
-      <SignupTextComponent text="ID" value={email} onChange={handleEmailChange} placeholder="ex) weeth@gmail.com" type="text" children='' />
+      <SignupTextComponent text="email" value={email} onChange={handleEmailChange} placeholder="ex) weeth@gmail.com" type="text" children='' />
       <TextMargin />
       <SignupTextComponent
-        text="PW"
+        text="password"
         value={password}
         onChange={handlePasswordChange}
         placeholder=""

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -77,11 +77,11 @@ const Login = () => {
     try {
       const response = await axios.post('http://13.125.78.31:8080/login', params, { withCredentials: true });
 
-      const validatedResponse = await Utils(response, axios.post, [params], navigate); // Use Utils to handle the response
+      const validatedResponse = await Utils(response, axios.post, [params], navigate);
 
       if (validatedResponse.status === 200) {
         setError(null);
-        navigate('/home'); // 로그인 성공 후 원하는 경로로 이동
+        navigate('/home');
       }
     } catch (err) {
       console.error('Error:', err);

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -6,6 +6,7 @@ import LoginHeader from '../components/Login/LoginHeader';
 import SignupTextComponent from '../components/Signup/SignupTextComponent';
 import { ReactComponent as ToggleVisibleIcon } from '../assets/images/ic_toggleVisible.svg';
 import { ReactComponent as ToggleInvisibleIcon } from '../assets/images/ic_toggleInvisible.svg';
+import Utils from '../hooks/Utils';
 
 const Container = styled.div`
   display: flex;
@@ -30,7 +31,6 @@ const ErrorMessage = styled.div`
   font-size: 14px;
   text-align: right;
   width: 100%;
-
 `;
 
 const Login = () => {
@@ -77,18 +77,11 @@ const Login = () => {
     try {
       const response = await axios.post('http://13.125.78.31:8080/login', params, { withCredentials: true });
 
-      if (response.status === 200) {
-        const token = response.headers['authorization'];
-        const refreshToken = response.headers['authorization-refresh'];
+      const validatedResponse = await Utils(response, axios.post, [params], navigate); // Use Utils to handle the response
 
-        if (token && refreshToken) {
-          localStorage.setItem('accessToken', token);
-          localStorage.setItem('refreshToken', refreshToken);
-          setError(null);
-          navigate('/home'); // 로그인 성공 후 원하는 경로로 이동
-        } else {
-          setError('토큰이 응답에 포함되지 않았습니다.');
-        }
+      if (validatedResponse.status === 200) {
+        setError(null);
+        navigate('/home'); // 로그인 성공 후 원하는 경로로 이동
       }
     } catch (err) {
       console.error('Error:', err);

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -23,6 +23,16 @@ const TextMargin = styled.div`
   margin-top: 30px;
 `;
 
+const ErrorMessage = styled.div`
+  right: 0;
+  color: #ff5858;
+  margin: 15px 0 0 -5%;
+  font-size: 14px;
+  text-align: right;
+  width: 100%;
+
+`;
+
 const Login = () => {
   const navigate = useNavigate();
   const [email, setEmail] = useState('');
@@ -100,10 +110,10 @@ const Login = () => {
     <Container>
       <LoginHeader isRightButtonEnabled={!!isAllValid} onCompleteClick={handleLogin} />
       <LoginHeaderMargin />
-      <SignupTextComponent text="email" value={email} onChange={handleEmailChange} placeholder="ex) weeth@gmail.com" type="text" children='' />
+      <SignupTextComponent text="ID" value={email} onChange={handleEmailChange} placeholder="ex) weeth@gmail.com" type="text" children='' />
       <TextMargin />
       <SignupTextComponent
-        text="password"
+        text="PW"
         value={password}
         onChange={handlePasswordChange}
         placeholder=""
@@ -131,7 +141,10 @@ const Login = () => {
           />
         )}
       </SignupTextComponent>
-      {error && <p style={{ color: 'red' }}>{error}</p>}
+      <ErrorMessage>
+        {error}
+      </ErrorMessage>
+      
     </Container>
   );
 };


### PR DESCRIPTION
## 1.  개발 내용
로그인 페이지 API 연결 및 기능 구현하기

## 2.  구현 세부 사항
로그인 페이지에서 이메일 입력 시 상황에 따른 에러 메시지 뜨게 하기 / 로그인 허용되도록 구현하기

- 이메일 불일치 문제
<img width="184" alt="image" src="https://github.com/user-attachments/assets/f90f9409-edbe-473a-b0e0-ad742add0a83">

- 비밀번호 불일치 문제
<img width="200" alt="image" src="https://github.com/user-attachments/assets/0ab98fc3-3068-4347-b9d7-d72eee3c719e">

- Utils.js의 기능:  페이지에서 토큰이 만료되었을 때, 토큰 재발급을 위한 용도

## 3. 메모
-Utils.js 사용 방법 :  Utils 함수를 호출해서 매개변수를 넣고, 저장한 변수를 사용하기 
-매개변수
   1. response: 응답객체
   2. originalApiFunc : 원래 호출된 API 함수
   3. originalParams: 원래 API 호출 시 사용된 매개변수들
   4. navigate: 다른 페이지로 리디렉션할 때 사용

-Utils.js 사용에 대한 상세한 적용 방법은 Login.jsx에서 확인하실 수 있습니다!(주석도 참고하기)
-원래는 case가 가입된 이메일이 아닌 경우까지 총 3가지인데 회원가입 API를 완료하지 못해서 아직은 안 보입니다!

