### PR TITLE
#143 feat: 일정 수정 api

### DIFF
--- a/src/components/BoardTitle.jsx
+++ b/src/components/BoardTitle.jsx
@@ -10,6 +10,7 @@ import LeftButton from './Header/LeftButton';
 import IndexButton from './Header/IndexButton';
 import theme from '../styles/theme';
 import EditDelModal from './EditDelModal';
+import UserAPI from '../hooks/UserAPI';
 
 Modal.setAppElement('#root');
 
@@ -92,6 +93,7 @@ const BoardTitle = ({ eventId, text, writer, createdAt }) => {
 
   return (
     <StyledTitle>
+      <UserAPI />
       <StyledHeader>
         <LeftButton />
         {userData.role === 'ADMIN' ? (

--- a/src/pages/EventDetails.jsx
+++ b/src/pages/EventDetails.jsx
@@ -1,20 +1,15 @@
-import React, { useContext } from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
-
 import { useParams } from 'react-router-dom';
+import axios from 'axios';
 
 import icCalendar from '../assets/images/ic_date.svg';
 import icClock from '../assets/images/ic_clock.svg';
 import theme from '../styles/theme';
 import BoardTitle from '../components/BoardTitle';
-// import mockEventMonth from '../components/mockData/mockEventMonth';
-import EventAPI from '../hooks/EventAPI';
-import { EventContext } from '../hooks/EventContext';
 
 const StyledEventDetails = styled.div`
   width: 370px;
-  // 해당페이지는 컴포넌트화될 예정이므로 따로 추가하지 않음
-  // 추후에 만들어질 컴포넌트에서 설정하겟습니당
 `;
 
 const ContentBlock = styled.div`
@@ -42,20 +37,49 @@ const Line = styled.div`
 
 const EventDetails = () => {
   const { id } = useParams();
+  const [eventDetailData, setEventDetailData] = useState(null);
+  const [error, setError] = useState(null);
 
-  const { monthEventData, error } = useContext(EventContext);
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const ACCESS_TOKEN = process.env.REACT_APP_ACCESS_TOKEN;
+        const headers = {
+          Authorization: `Bearer ${ACCESS_TOKEN}`,
+        };
+
+        if (id) {
+          const response = await axios.get(
+            `http://13.125.78.31:8080/event/${id}`,
+            { headers },
+          );
+          if (response.data.code === 200) {
+            console.log('response detail data:', response.data.data); // 데이터 확인용
+            setEventDetailData(response.data.data);
+          } else {
+            console.error('Error message from API:', response.data.message);
+            setError(response.data.message);
+          }
+        }
+      } catch (err) {
+        console.error('API Request Error:', err); // 에러 로그
+        setError('An error occurred while fetching the data');
+      }
+    };
+
+    fetchData();
+  }, [id]);
+
   if (error) {
     return <div>Error: {error}</div>;
   }
 
-  if (!monthEventData) {
+  if (!eventDetailData) {
     return <div>Loading...</div>;
   }
-  // eslint-disable-next-line no-shadow, radix
-  const event = monthEventData.find((event) => event.id === parseInt(id));
 
-  const origStartDate = event.start;
-  const origEndDate = event.end;
+  const origStartDate = eventDetailData.start;
+  const origEndDate = eventDetailData.end;
 
   const splittedStartDate = origStartDate.split('T'); // YYYY-MM-DD,HH:MM:SS.SSSZ
   const startDate = splittedStartDate[0].split('-'); // [YYYY, MM, DD]
@@ -67,7 +91,6 @@ const EventDetails = () => {
 
   const weekDay = ['일', '월', '화', '수', '목', '금', '토'];
 
-  // 시작 날짜와 끝 날짜가 같은지 확인
   let isOneday = true;
   // eslint-disable-next-line no-plusplus
   for (let i = 0; i < startDate.length; i++) {
@@ -78,20 +101,18 @@ const EventDetails = () => {
 
   return (
     <StyledEventDetails>
-      <EventAPI />
       <BoardTitle
-        eventId={event.id}
-        text={event.title}
-        writer={event.userName}
-        createdAt={event.createdAt}
+        eventId={eventDetailData.id}
+        text={eventDetailData.title}
+        writer={eventDetailData.userName}
+        createdAt={eventDetailData.createdAt}
       />
       <Line />
       <ContentBlock>
         {isOneday ? (
-          // 하루 일정일 때
           <>
             <TimeInfo>
-              <Icon src={icCalendar} alt="calenar" />
+              <Icon src={icCalendar} alt="calendar" />
               <div>
                 {startDate[0]}년 {parseInt(startDate[1], 10)}월{' '}
                 {parseInt(startDate[2], 10)}일{' '}
@@ -106,10 +127,9 @@ const EventDetails = () => {
             </TimeInfo>
           </>
         ) : (
-          // 긴 일정일 때
           <>
             <TimeInfo>
-              <Icon src={icCalendar} alt="calenar" />
+              <Icon src={icCalendar} alt="calendar" />
               <div>
                 {startDate[0]}년 {parseInt(startDate[1], 10)}월{' '}
                 {parseInt(startDate[2], 10)}일 &#40;
@@ -130,12 +150,12 @@ const EventDetails = () => {
         )}
       </ContentBlock>
       <ContentBlock>
-        <div>장소 : {event.location} </div>
-        <div>준비물 : {event.requiredItems} </div>
-        <div>총 인원 : {event.memberNumber}</div>
+        <div>장소 : {eventDetailData.location} </div>
+        <div>준비물 : {eventDetailData.requiredItems} </div>
+        <div>총 인원 : {eventDetailData.memberNumber}</div>
       </ContentBlock>
       <ContentBlock>
-        <div>{event.content}</div>
+        <div>{eventDetailData.content}</div>
       </ContentBlock>
     </StyledEventDetails>
   );


### PR DESCRIPTION
## 1. 개발내용
일정 수정 api 연결

## 2. 구현 세부사항
1. /event/{eventId} 가져오는 api 수정.. 
- 원래 일정 상세페이지가.. 캘린더에서 받아온 기간 일정 중 해당하는 id의 값을 함께 넘겨주면서 렌더링하는거라 새로고침하면 값이 사라졋는데, 상세페이지에서 api를 받아오도록 수정해서 새로고침 가능합니다^_^~
- 추후 리팩토링이 필요할 것 같음. context로 가져오려햇으나 어떻게 해도 안되더라구요.. 이러다가 완성을 못할 것 같아서 그냥 냅다 연결햇습니다
2. 수정 api도 구현 완료!
이게 api 연결은 금방 햇는데 원래 데이터를 가져와서 보여주는 게 잘 안돼서 오래걸렷네요... ^_ㅠ