### PR TITLE
#172 feat: 일정 관련 수정

### DIFF
--- a/src/components/Calendar/MonthCalendar.jsx
+++ b/src/components/Calendar/MonthCalendar.jsx
@@ -95,6 +95,8 @@ const CalendarContainer = styled.div`
   .fc-event-title {
     font-weight: 400;
     padding: 0px;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 `;
 

--- a/src/components/Calendar/MonthlyEvent.jsx
+++ b/src/components/Calendar/MonthlyEvent.jsx
@@ -59,7 +59,7 @@ EventComponent.propTypes = {
   title: PropTypes.string.isRequired,
 };
 
-const MonthlyEvent = ({ thisMonth, month, year }) => {
+const MonthlyEvent = ({ thisMonth, year }) => {
   const [yearEventData, setYearEventData] = useState(null);
   const [error, setError] = useState(null);
   const navigate = useNavigate();
@@ -126,7 +126,9 @@ const MonthlyEvent = ({ thisMonth, month, year }) => {
     return <div>Loading...</div>;
   }
 
-  const istoday = thisMonth === month;
+  const todayMonth = new Date().getMonth() + 1;
+  const todayYear = new Date().getFullYear();
+  const istoday = thisMonth === todayMonth && todayYear === year;
   const events = yearEventData[thisMonth] || [];
 
   return (
@@ -147,7 +149,6 @@ const MonthlyEvent = ({ thisMonth, month, year }) => {
 
 MonthlyEvent.propTypes = {
   thisMonth: PropTypes.number.isRequired,
-  month: PropTypes.number.isRequired,
   year: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
 };
 

--- a/src/components/Calendar/YearCalendar.jsx
+++ b/src/components/Calendar/YearCalendar.jsx
@@ -22,7 +22,7 @@ const OddMonth = styled.div`
 
 const allMonth = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
 
-const YearCalendar = ({ month, year }) => {
+const YearCalendar = ({ year }) => {
   const yearNumber = parseInt(year, 10); // 문자열을 숫자로 변환
   return (
     <MonthlyBox>
@@ -33,7 +33,6 @@ const YearCalendar = ({ month, year }) => {
             <MonthlyEvent
               key={monthItem}
               thisMonth={monthItem}
-              month={month}
               year={yearNumber}
             />
           ))}
@@ -45,7 +44,6 @@ const YearCalendar = ({ month, year }) => {
             <MonthlyEvent
               key={monthItem}
               thisMonth={monthItem}
-              month={month}
               year={yearNumber}
             />
           ))}
@@ -55,7 +53,6 @@ const YearCalendar = ({ month, year }) => {
 };
 
 YearCalendar.propTypes = {
-  month: PropTypes.number.isRequired,
   year: PropTypes.number.isRequired,
 };
 

--- a/src/hooks/Utils.js
+++ b/src/hooks/Utils.js
@@ -40,3 +40,7 @@ const Utils = async (response, originalApiFunc, originalParams, navigate) => {
 };
 
 export default Utils;
+
+export const replaceNewLines = (text) => {
+  return text.replace(/\r?\n/g, '\\n');
+};

--- a/src/pages/Calendar.jsx
+++ b/src/pages/Calendar.jsx
@@ -48,7 +48,7 @@ const Calendar = () => {
       <CalendarHeader month={month} year={year} isYear={isYear} editYear={editYear} editMonth={editMonth} />
       <Content>
         <ToggleButton onToggle={onToggle} />
-        {calendarType === 'month' ? <MonthCalendar month={month} year={year} editYear={editYear} editMonth={editMonth} /> : <YearCalendar year={year} month={month}/>}
+        {calendarType === 'month' ? <MonthCalendar month={month} year={year} editYear={editYear} editMonth={editMonth} /> : <YearCalendar year={year} />}
       </Content>
     </StyledCalendar>
   );

--- a/src/pages/CreateEvent.jsx
+++ b/src/pages/CreateEvent.jsx
@@ -12,6 +12,7 @@ import InfoInput from '../components/MyPage/InfoInput';
 import icCalendar from '../assets/images/ic_date.svg';
 import icWave from '../assets/images/ic_wave.svg';
 import DateInput from '../components/Calendar/DateInput';
+import { replaceNewLines } from '../hooks/Utils';
 
 const StyledCreate = styled.div`
   display: flex;
@@ -173,7 +174,10 @@ const CreateEvent = () => {
 
   const onSave = async () => {
     const title = eventInfo.find((item) => item.key === 'title').value;
-    const content = eventInfo.find((item) => item.key === 'content').value;
+    let content = eventInfo.find((item) => item.key === 'content').value;
+
+    // 엔터를 \n으로 치환
+    content = replaceNewLines(content);
 
     // 작성한 내용 저장
     const data = eventInfo.reduce((acc, item) => {

--- a/src/pages/EventDetails.jsx
+++ b/src/pages/EventDetails.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { useParams } from 'react-router-dom';

--- a/src/pages/EventDetails.jsx
+++ b/src/pages/EventDetails.jsx
@@ -11,6 +11,7 @@ import EventInfoAPI from '../hooks/EventInfoAPI';
 
 const StyledEventDetails = styled.div`
   width: 370px;
+  margin-bottom: 50px;
 `;
 
 const ContentBlock = styled.div`
@@ -18,6 +19,7 @@ const ContentBlock = styled.div`
   padding: 15px;
   border-radius: 20px;
   margin: 10px;
+  white-space: pre-wrap;
 `;
 
 const TimeInfo = styled.div`


### PR DESCRIPTION
## 1. 개발 내용
일정 관련 수정

## 2. 구현 세부사항
**✔️ 일정 상세페이지에서 내용에 줄바꿈처리**
- css 설정 추가하여 \n을 줄바꿈으로 보이도록
- 수정페이지가 자꾸 문제가 많아서 .. 생성-수정이 같은 컴포넌트를 공유하도록 리팩토링해서 해결할 예정! axios함수랑 input 초기필드만 달라서 공유하는 편이 효율적일듯.

**✔️ 현재달 표시 수정**
- 원래는 month 변수를 이용하여 확인했는데, month가 state값이라서... 캘린더(달)에서 달을 변경하면 현재달 표시도 꼬이는 이슈
- Date객체를 새로 만들어서 비교하는 방법으로 해결
- 해결하면서 현재 년도가 아닌 경우에는 현재달이 표시되지 않도록 수정함 (2023년으로 넘길 경우 2023년 8월에도 현재달 표시가 됐었는데, 2024년 8월인 경우에만 표시되도록 함)

**✔️ 달력에 표시되는 일정 제목은 일단 css로 말줄임표 처리함**

## 3. 메모
남은 수정 이슈들이 거의 css거나 모든 페이지에 공통으로 사용되는 부분이라 (+해결이 잘 안돼서,,) 리팩토링 먼저 진행하겟습니당,,,,