### PR TITLE
#177 fix: api 수정

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,4 @@
-# App.js
+App.js
 Calendar.jsx
 Attendance.jsx
 Button.jsx

--- a/src/App.js
+++ b/src/App.js
@@ -56,6 +56,7 @@ function App() {
           <Route path="/login" element={<Login />} />
           <Route path="/attendance" element={<Attendance />} />
           <Route path="/calendar" element={<Calendar />} />
+          <Route path="/meeting/:id" element={<EventDetails />} />
           <Route path="/event/:id" element={<EventDetails />} />
           <Route path="/event/create" element={<CreateEvent />} />
           <Route path="/event/:id/edit" element={<EditEvent />} />

--- a/src/App.js
+++ b/src/App.js
@@ -35,6 +35,7 @@ import { BoardProvider } from './hooks/BoardContext';
 import { DuesProvider } from './hooks/DuesContext';
 import { EventInfoProvider } from './hooks/EventInfoContext';
 import { NoticeProvider } from './hooks/NoticeContext';
+import { YearlyScheduleProvider } from './hooks/YearlyScheduleContext';
 
 //user api 받아온 정보 담는 context
 
@@ -47,6 +48,7 @@ function App() {
       <DuesProvider>
       <EventInfoProvider>
       <NoticeProvider>
+      <YearlyScheduleProvider>
       <UserAPI />
       <MonthlyScheduleAPI />
         <Routes>
@@ -72,6 +74,7 @@ function App() {
           <Route path="/boardPosting" element={<BoardPosting />} />
           <Route path="/boardEdit" element={<BoardEdit />} />
         </Routes>
+        </YearlyScheduleProvider>
         </NoticeProvider>
         </EventInfoProvider>
         </DuesProvider>

--- a/src/components/BoardTitle.jsx
+++ b/src/components/BoardTitle.jsx
@@ -83,14 +83,18 @@ const BoardTitle = ({ eventId, text, writer, createdAt }) => {
     const BASE_URL = process.env.REACT_APP_BASE_URL;
     if (window.confirm('삭제하시겠습니까?')) {
       try {
-        await axios.delete(`${BASE_URL}/admin/event/${eventId}`, {
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-            Authorization_refresh: `Bearer ${refreshToken}`,
+        const response = await axios.delete(
+          `${BASE_URL}/api/v1/admin/events/${eventId}`,
+          {
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+              Authorization_refresh: `Bearer ${refreshToken}`,
+            },
           },
-        });
+        );
         alert('삭제가 완료되었습니다.');
-        navi('/calendar'); // 탈퇴 후 메인 페이지로 이동
+        console.log(response);
+        navi('/calendar');
       } catch (err) {
         alert('삭제 중 오류가 발생했습니다.');
       }

--- a/src/components/Calendar/MonthCalendar.jsx
+++ b/src/components/Calendar/MonthCalendar.jsx
@@ -124,8 +124,6 @@ const MonthCalendar = ({ year, month }) => {
   const prevMonth = month - 1;
   const nextMonth = month + 1;
 
-  let id;
-
   const [formattedStart, setFormattedStart] = useState(
     `${year}-${String(prevMonth).padStart(2, '0')}-23T00:00:00.000Z`,
   );
@@ -133,7 +131,6 @@ const MonthCalendar = ({ year, month }) => {
     new Date(year, nextMonth, 6, 23, 59, 59, 999).toISOString(),
   );
 
-  // 에러처리에 자꾸 오류가 떠서 일단 오류 안나게 지피티가 만들어줌.. 수정 예정
   useEffect(() => {
     if (error) {
       console.error('Error:', error);
@@ -145,6 +142,16 @@ const MonthCalendar = ({ year, month }) => {
       console.log('Loading event data...');
     }
   }, [monthScheduleData]);
+
+  // 데이터 전처리 함수
+  const preprocessData = (data) => {
+    return data.map((event) => ({
+      ...event,
+      id: `${event.id}_${event.isMeeting}`, // 고유 ID 생성
+    }));
+  };
+
+  const processedData = preprocessData(monthScheduleData || []);
 
   const renderDayCell = (arg) => {
     const isToday =
@@ -158,18 +165,20 @@ const MonthCalendar = ({ year, month }) => {
   };
 
   const onClickEvent = (clickInfo) => {
-    id = clickInfo.event.id;
-    navi(`/event/${id}`);
+    const [id] = clickInfo.event.id.split('_'); // 원래 ID 추출
+    const { isMeeting } = clickInfo.event.extendedProps;
+
+    if (isMeeting) {
+      navi(`/meeting/${id}`, { state: { isMeeting } });
+    } else {
+      navi(`/event/${id}`, { state: { isMeeting } });
+    }
   };
 
   useEffect(() => {
-    // 달력 자체에 이전달/다음달 일부가 보여지는 것을 고려하여
-    // 조회를 원하는 달에서 +-1주 기간을 추가하여 api 요청
     setFormattedStart(
-      // 2월의 경우 3월 1일이 토요일이라면 23일부터 보여질 수 있음
       `${year}-${String(prevMonth).padStart(2, '0')}-23T00:00:00.000Z`,
     );
-    // UTC 기준이라 대한민국 표준시로는 6일 23시임
     setFormattedEnd(new Date(year, month, 7, 8, 59, 59, 999).toISOString());
   }, [year, month]);
 
@@ -191,7 +200,7 @@ const MonthCalendar = ({ year, month }) => {
       <FullCalendar
         ref={calendarRef}
         plugins={[dayGridPlugin]}
-        events={monthScheduleData || []}
+        events={processedData}
         eventClick={onClickEvent}
         locale="ko"
         headerToolbar={false}

--- a/src/components/Calendar/MonthCalendar.jsx
+++ b/src/components/Calendar/MonthCalendar.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import React, { useEffect, useRef, useContext, useState } from 'react';
 import FullCalendar from '@fullcalendar/react';
 import dayGridPlugin from '@fullcalendar/daygrid';
@@ -120,7 +121,6 @@ const MonthCalendar = ({ year, month }) => {
 
   const { monthScheduleData, error } = useContext(MonthlyScheduleContext);
 
-  console.log(monthScheduleData);
   const prevMonth = month - 1;
   const nextMonth = month + 1;
 

--- a/src/components/Calendar/MonthlyEvent.jsx
+++ b/src/components/Calendar/MonthlyEvent.jsx
@@ -1,11 +1,12 @@
-import React, { useState, useEffect } from 'react';
-import axios from 'axios';
+/* eslint-disable no-unused-vars */
+/* eslint-disable no-console */
+import React, { useContext } from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
-import { useNavigate } from 'react-router-dom';
 import theme from '../../styles/theme';
 import icDot from '../../assets/images/ic_dot.svg';
-import Utils from '../../hooks/Utils';
+import { YearlyScheduleContext } from '../../hooks/YearlyScheduleContext';
+import YearlyScheduleAPI from '../../hooks/YearlyScheduleAPI';
 
 const StyledYear = styled.div`
   display: flex;
@@ -60,76 +61,20 @@ EventComponent.propTypes = {
 };
 
 const MonthlyEvent = ({ thisMonth, year }) => {
-  const [yearEventData, setYearEventData] = useState(null);
-  const [error, setError] = useState(null);
-  const navigate = useNavigate();
-
-  const yearNumber = parseInt(year, 10);
-
-  useEffect(() => {
-    const fetchData = async () => {
-      const BASE_URL = process.env.REACT_APP_BASE_URL;
-      const accessToken = localStorage.getItem('accessToken');
-      const refreshToken = localStorage.getItem('refreshToken');
-
-      try {
-        if (year) {
-          let response = await axios.get(`${BASE_URL}/event/year`, {
-            headers: {
-              Authorization: `Bearer ${accessToken}`,
-              Authorization_refresh: `Bearer ${refreshToken}`,
-            },
-            params: {
-              year: yearNumber,
-            },
-          });
-
-          response = await Utils(
-            response,
-            axios.get,
-            [
-              `${BASE_URL}/event/year`,
-              {
-                headers: {
-                  Authorization: `Bearer ${accessToken}`,
-                },
-                params: {
-                  year: yearNumber,
-                },
-              },
-            ],
-            navigate,
-          );
-
-          if (response.data.code === 200) {
-            console.log('response data', response.data.data);
-            setYearEventData(response.data.data);
-          } else {
-            console.log(response);
-            setError('error!', response.data.message);
-          }
-        }
-      } catch (err) {
-        console.error('API Request Error:', err); // 에러 로그
-        setError('An error occurred while fetching the data');
-      }
-    };
-
-    fetchData();
-  }, [year, navigate]);
+  const { yearScheduleData, error } = useContext(YearlyScheduleContext);
 
   if (error) {
     return <div>Error: {error}</div>;
   }
 
-  if (!yearEventData) {
+  if (!yearScheduleData) {
     return <div>Loading...</div>;
   }
 
   const todayMonth = new Date().getMonth() + 1;
   const todayYear = new Date().getFullYear();
   const istoday = thisMonth === todayMonth && todayYear === year;
-  const events = yearEventData[thisMonth] || [];
+  const events = yearScheduleData[thisMonth] || [];
 
   return (
     <StyledYear>

--- a/src/components/Calendar/YearCalendar.jsx
+++ b/src/components/Calendar/YearCalendar.jsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 
 import MonthlyEvent from './MonthlyEvent';
+import YearlyScheduleAPI from '../../hooks/YearlyScheduleAPI';
 
 const MonthlyBox = styled.div`
   display: flex;
@@ -24,8 +25,23 @@ const allMonth = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
 
 const YearCalendar = ({ year }) => {
   const yearNumber = parseInt(year, 10); // 문자열을 숫자로 변환
+
+  const [formattedStart, setFormattedStart] = useState(
+    `${year}-01-01T00:00:00.000Z`,
+  );
+  const [formattedEnd, setFormattedEnd] = useState(
+    `${year}-12-31T23:59:59.999Z`,
+  );
+
+  useEffect(() => {
+    setFormattedStart(`${year}-01-01T00:00:00.000Z`);
+    // UTC 기준이라 대한민국 표준시로는 6일 23시임
+    setFormattedEnd(`${year}-12-31T23:59:59.999Z`);
+  }, [year]);
+
   return (
     <MonthlyBox>
+      <YearlyScheduleAPI start={formattedStart} end={formattedEnd} />
       <EvenMonth>
         {allMonth
           .filter((monthItem) => monthItem % 2 !== 0)

--- a/src/hooks/EventInfoAPI.jsx
+++ b/src/hooks/EventInfoAPI.jsx
@@ -5,7 +5,6 @@ import { EventInfoContext } from './EventInfoContext';
 
 const EventInfoAPI = ({ id }) => {
   const { setInfoData, setError } = useContext(EventInfoContext);
-  console.log('넘겨준 좀 위에', id);
 
   useEffect(() => {
     const accessToken = localStorage.getItem('accessToken');
@@ -17,8 +16,6 @@ const EventInfoAPI = ({ id }) => {
       Authorization_refresh: `Bearer ${refreshToken}`,
     };
     const fetchData = async () => {
-      console.log('넘겨준', id);
-
       try {
         if (id) {
           const response = await axios.get(`${BASE_URL}/event/${id}`, {

--- a/src/hooks/YearlyScheduleAPI.jsx
+++ b/src/hooks/YearlyScheduleAPI.jsx
@@ -2,11 +2,11 @@ import { useEffect, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import PropTypes from 'prop-types';
-import { MonthlyScheduleContext } from './MonthlyScheduleContext';
+import { YearlyScheduleContext } from './YearlyScheduleContext';
 import Utils from './Utils';
 
-const MonthlyScheduleAPI = ({ start, end }) => {
-  const { setMonthScheduleData, setError } = useContext(MonthlyScheduleContext);
+const YearlyScheduleAPI = ({ start, end }) => {
+  const { setYearScheduleData, setError } = useContext(YearlyScheduleContext);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -27,45 +27,45 @@ const MonthlyScheduleAPI = ({ start, end }) => {
       };
 
       try {
-        let response = await axios.get(`${BASE_URL}/api/v1/schedules/monthly`, {
+        let response = await axios.get(`${BASE_URL}/api/v1/schedules/yearly`, {
           headers,
           params,
         });
-
+        console.log('util상관없이 받아온거');
         // Utils 함수를 사용하여 응답 처리 및 토큰 갱신
         response = await Utils(
           response,
           axios.get,
-          [{ url: `${BASE_URL}/api/v1/schedules/monthly`, headers, params }],
+          [{ url: `${BASE_URL}/api/v1/schedules/yearly`, headers, params }],
           navigate,
         );
 
         if (response.data.code === 200) {
-          console.log('월별 조회', response.data.data); // 데이터 확인용
-          setMonthScheduleData(response.data.data);
+          console.log('모든 게 성공햇을 때.. 서버 응답', response.data.data); // 데이터 확인용
+          setYearScheduleData(response.data.data);
         } else {
           setError(response.data.message);
         }
       } catch (err) {
-        console.error('월별 조회 에러', err); // 에러 로그
+        console.error('에러', err); // 에러 로그
         setError('An error occurred while fetching the data');
       }
     };
 
     fetchData();
-  }, [navigate, setMonthScheduleData, setError, start, end]);
+  }, [navigate, setYearScheduleData, setError, start, end]);
 
   return null;
 };
 
-MonthlyScheduleAPI.propTypes = {
+YearlyScheduleAPI.propTypes = {
   start: PropTypes.string,
   end: PropTypes.string,
 };
 
-MonthlyScheduleAPI.defaultProps = {
+YearlyScheduleAPI.defaultProps = {
   start: '',
   end: '',
 };
 
-export default MonthlyScheduleAPI;
+export default YearlyScheduleAPI;

--- a/src/hooks/YearlyScheduleContext.js
+++ b/src/hooks/YearlyScheduleContext.js
@@ -1,0 +1,20 @@
+/* eslint-disable react/jsx-no-constructed-context-values */
+/* eslint-disable react/prop-types */
+import React, { createContext, useState } from 'react';
+
+// Context 객체 생성
+export const YearlyScheduleContext = createContext();
+
+// Provider 컴포넌트
+export const YearlyScheduleProvider = ({ children }) => {
+  const [yearScheduleData, setYearScheduleData] = useState(null);
+  const [error, setError] = useState(null);
+
+  return (
+    <YearlyScheduleContext.Provider
+      value={{ yearScheduleData, setYearScheduleData, error, setError }}
+    >
+      {children}
+    </YearlyScheduleContext.Provider>
+  );
+};

--- a/src/pages/CreateEvent.jsx
+++ b/src/pages/CreateEvent.jsx
@@ -258,12 +258,16 @@ const CreateEvent = () => {
 
     if (window.confirm('저장하시겠습니까?')) {
       try {
-        const response = await axios.post(`${BASE_URL}/admin/event`, data, {
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-            Authorization_refresh: `Bearer ${refreshToken}`,
+        const response = await axios.post(
+          `${BASE_URL}/api/v1/admin/events`,
+          data,
+          {
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+              Authorization_refresh: `Bearer ${refreshToken}`,
+            },
           },
-        });
+        );
         console.log(response); // 서버의 응답을 콘솔에 출력
         console.log(data);
         alert('저장이 완료되었습니다.');

--- a/src/pages/CreateEvent.jsx
+++ b/src/pages/CreateEvent.jsx
@@ -143,11 +143,11 @@ DatePicker.propTypes = {
 const CreateEvent = () => {
   const [eventInfo, setEventInfo] = useState([
     { key: 'title', value: '' },
-    { key: 'startDateTime', value: getValue('start') },
-    { key: 'endDateTime', value: [] },
+    { key: 'start', value: getValue('start') },
+    { key: 'end', value: [] },
     { key: 'location', value: '' },
-    { key: 'requiredItems', value: '' },
-    { key: 'memberNumber', value: '' },
+    { key: 'requiredItem', value: '' },
+    { key: 'memberCount', value: '' },
     { key: 'content', value: '' },
   ]);
 
@@ -194,14 +194,12 @@ const CreateEvent = () => {
       return acc;
     }, {});
 
-    let startDateTime = '';
-    let endDateTime = '';
+    let start = '';
+    let end = '';
 
     // 시간 배열로 저장
-    const startDate = eventInfo.find(
-      (item) => item.key === 'startDateTime',
-    ).value;
-    const endDate = eventInfo.find((item) => item.key === 'endDateTime').value;
+    const startDate = eventInfo.find((item) => item.key === 'start').value;
+    const endDate = eventInfo.find((item) => item.key === 'end').value;
 
     // 시작 시간 배열 -> ISO 형식으로 변환
     if (startDate.length === 5) {
@@ -214,8 +212,8 @@ const CreateEvent = () => {
         startHour,
         startMinute,
       );
-      startDateTime = toKSTISOString(startDateObj);
-      data.startDateTime = startDateTime;
+      start = toKSTISOString(startDateObj);
+      data.start = start;
     }
 
     // 종료 시간 배열 -> ISO 형식으로 변환
@@ -228,19 +226,16 @@ const CreateEvent = () => {
         endHour,
         endMinute,
       );
-      endDateTime = toKSTISOString(endDateObj);
-      data.endDateTime = endDateTime;
+      end = toKSTISOString(endDateObj);
+      data.end = end;
     }
 
-    console.log('start', data.startDateTime);
-    console.log('end', data.endDateTime);
-
-    if (data.startDateTime === data.endDateTime) {
+    if (data.start === data.end) {
       alert('시작 시간과 종료 시간은 같을 수 없습니다.');
       return;
     }
 
-    if (data.startDateTime > data.endDateTime) {
+    if (data.start > data.end) {
       alert('종료 시간은 시작 시간보다 빠를 수 없습니다.');
       return;
     }
@@ -299,20 +294,20 @@ const CreateEvent = () => {
           status="start"
           onDateChange={(index, value) => {
             const startDate = [
-              ...eventInfo.find((item) => item.key === 'startDateTime').value,
+              ...eventInfo.find((item) => item.key === 'start').value,
             ];
             startDate[index] = value;
-            editDate('startDateTime', startDate);
+            editDate('start', startDate);
           }}
         />
         <DatePicker
           status="end"
           onDateChange={(index, value) => {
             const endDate = [
-              ...eventInfo.find((item) => item.key === 'endDateTime').value,
+              ...eventInfo.find((item) => item.key === 'end').value,
             ];
             endDate[index] = value;
-            editDate('endDateTime', endDate);
+            editDate('end', endDate);
           }}
         />
       </DatePickerWrapper>
@@ -329,22 +324,22 @@ const CreateEvent = () => {
       <InfoInput
         text="준비물"
         origValue={
-          eventInfo.find((item) => item.key === 'requiredItems')?.value || ''
+          eventInfo.find((item) => item.key === 'requiredItem')?.value || ''
         }
         width="75%"
         padding="15px"
         align="left"
-        editValue={(value) => editValue('requiredItems', value)}
+        editValue={(value) => editValue('requiredItem', value)}
       />
       <InfoInput
         text="총인원"
         origValue={
-          eventInfo.find((item) => item.key === 'memberNumber')?.value || ''
+          eventInfo.find((item) => item.key === 'memberCount')?.value || ''
         }
         width="75%"
         padding="15px"
         align="left"
-        editValue={(value) => editValue('memberNumber', value)}
+        editValue={(value) => editValue('memberCount', value)}
       />
       <StyledTextArea
         placeholder="내용"

--- a/src/pages/EventDetails.jsx
+++ b/src/pages/EventDetails.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
-import { useParams } from 'react-router-dom';
+import { useParams, useLocation } from 'react-router-dom';
 import axios from 'axios';
 
 import icCalendar from '../assets/images/ic_date.svg';
@@ -43,6 +43,9 @@ const EventDetails = () => {
   const { id } = useParams();
   const [eventDetailData, setEventDetailData] = useState(null);
   const [error, setError] = useState(null);
+  const location = useLocation();
+  const { isMeeting } = location.state || {};
+  const apiType = isMeeting ? 'meetings' : 'events';
 
   useEffect(() => {
     const fetchData = async () => {
@@ -58,9 +61,12 @@ const EventDetails = () => {
         };
 
         if (id) {
-          const response = await axios.get(`${BASE_URL}/event/${id}`, {
-            headers,
-          });
+          const response = await axios.get(
+            `${BASE_URL}/api/v1/${apiType}/${id}`,
+            {
+              headers,
+            },
+          );
           if (response.data.code === 200) {
             console.log('response detail data:', response.data.data); // 데이터 확인용
             setEventDetailData(response.data.data);
@@ -113,7 +119,7 @@ const EventDetails = () => {
       <BoardTitle
         eventId={eventDetailData.id}
         text={eventDetailData.title}
-        writer={eventDetailData.userName}
+        writer={eventDetailData.name}
         createdAt={eventDetailData.createdAt}
       />
       <Line />
@@ -160,8 +166,8 @@ const EventDetails = () => {
       </ContentBlock>
       <ContentBlock>
         <div>장소 : {eventDetailData.location} </div>
-        <div>준비물 : {eventDetailData.requiredItems} </div>
-        <div>총 인원 : {eventDetailData.memberNumber}</div>
+        <div>준비물 : {eventDetailData.requiredItem} </div>
+        <div>총 인원 : {eventDetailData.memberCount}</div>
       </ContentBlock>
       <ContentBlock>
         <div>{eventDetailData.content}</div>


### PR DESCRIPTION
## 1. 개발 내용
서버 수정에 따른 api url 및 dto 수정

## 2. 구현 세부사항
- api 및 dto 수정
- isMeeting값에 따라 각각 다른 api를 불러오도록 수정

## 3. 메모
- event를 조회하면 event와 meeting의 값이 전부 반환되는데, event와 meeting끼리는 id가 겹쳐서 캘린더에서 꼬이는 이슈가 있었음
- 우선은 상세 페이지 api연결을 위해 프론트에서 중복 id를 처리했지만 이 부분을 프론트/백 중 어디에서 처리하는 게 좋을지, 혹은 다른 방법이 없을지는 조금 더 고민을 해봐야할듯함!
- 리팩토링 후 일정 수정이 사용될 수 있도록 하려 했으나,,, 해당 이슈가 너무 길어질 것 같아서 리팩토링은 새 이슈를 만들어서 해결하도록 하겠습니당 !! 현재는 일정 수정이 제대로 되지 않는 게 맞습니다... !!
- App.js에서 충돌이 났는데 해당부분 롤백했다고 해서 기존 파일을 남겨두는 방향으로 충돌 해결햇습니다,,