### PR TITLE
#196 fix: 멤버 카테고리 및 뒤로가기 수정

### DIFF
--- a/src/components/Calendar/MonthCalendar.jsx
+++ b/src/components/Calendar/MonthCalendar.jsx
@@ -97,6 +97,7 @@ const CalendarContainer = styled.div`
     padding: 0px;
     overflow: hidden;
     text-overflow: ellipsis;
+    font-weight: 400; //볼드가 자동으로 생겨서 강제로 굵기를 조절했음
   }
 `;
 

--- a/src/components/DropdownMenu.jsx
+++ b/src/components/DropdownMenu.jsx
@@ -57,12 +57,12 @@ const DropdownMenu = ({ text, origValue, editValue }) => {
   const dropdownRef = useRef(null);
 
   const options = [
-    { value: 'BUSINESS', label: '경영학과' },
-    { value: 'VISUAL_DESIGN', label: '시각디자인학과' },
-    { value: 'INDUSTRIAL_ENGINEERING', label: '산업공학과' },
-    { value: 'SW', label: '소프트웨어전공' },
-    { value: 'AI', label: '인공지능전공' },
-    { value: 'COMPUTERSCIENCE', label: '컴퓨터공학과' },
+    { value: '경영학과', label: '경영학과' },
+    { value: '시각디자인학과', label: '시각디자인학과' },
+    { value: '산업공학과', label: '산업공학과' },
+    { value: '소프트웨어전공', label: '소프트웨어전공' },
+    { value: '인공지능전공', label: '인공지능전공' },
+    { value: '컴퓨터공학과', label: '컴퓨터공학과' },
   ];
 
   const handleToggle = () => {

--- a/src/components/Member/Category.jsx
+++ b/src/components/Member/Category.jsx
@@ -1,19 +1,41 @@
-import styled from 'styled-components';
-import { useState } from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { useState, useRef } from 'react';
+import { useDraggable } from '../../hooks/useDraggable';
 import theme from '../../styles/theme';
 
 const StyledCategory = styled.div`
+  display: flex;
   padding-top: 20px;
+  overflow-x: auto;
+  white-space: nowrap;
   font-family: ${theme.font.family.pretendard_regulars};
   font-size: 16px;
+`;
+
+const ScrollContainer = styled.div`
+  display: flex;
+  width: 94%;
+  overflow-x: auto;
+  cursor: grab;
+  &::-webkit-scrollbar {
+    height: 1px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    border-radius: 4px;
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+  }
 `;
 
 const Button = styled.button`
   background-color: transparent;
   border: none;
   height: 39px;
-  width: 22%;
+  width: 62px;
+  flex-shrink: 0;
   border: 2px solid;
   border-width: 0 0 2px;
   border-color: ${(props) => (props.checked ? 'white' : 'transparent')};
@@ -26,44 +48,60 @@ const Button = styled.button`
 const Category = ({ setSelectedCardinal }) => {
   const [selectedCategory, setSelectedCategory] = useState(0);
 
-  const onClickAll = () => {
-    setSelectedCategory(0);
-    setSelectedCardinal(0);
+  const onClickCardinal = (index) => {
+    setSelectedCategory(index);
+    setSelectedCardinal(index);
   };
 
-  const onClick1 = () => {
-    setSelectedCategory(1);
-    setSelectedCardinal(1);
-  };
-
-  const onClick2 = () => {
-    setSelectedCategory(2);
-    setSelectedCardinal(2);
-  };
-
-  const onClick3 = () => {
-    setSelectedCategory(3);
-    setSelectedCardinal(3);
-  };
+  const scrollerRef1 = useRef(null);
+  const { onMouseDown, onMouseMove, onMouseUp, onMouseLeave } =
+    useDraggable(scrollerRef1);
 
   return (
     <StyledCategory>
-      <Button
-        type="button"
-        checked={selectedCategory === 0}
-        onClick={onClickAll}
+      <ScrollContainer
+        ref={scrollerRef1}
+        onMouseDown={onMouseDown}
+        onMouseMove={onMouseMove}
+        onMouseUp={onMouseUp}
+        onMouseLeave={onMouseLeave}
       >
-        전체
-      </Button>
-      <Button type="button" checked={selectedCategory === 1} onClick={onClick1}>
-        1기
-      </Button>
-      <Button type="button" checked={selectedCategory === 2} onClick={onClick2}>
-        2기
-      </Button>
-      <Button type="button" checked={selectedCategory === 3} onClick={onClick3}>
-        3기
-      </Button>
+        <Button
+          type="button"
+          checked={selectedCategory === 0}
+          onClick={() => onClickCardinal(0)}
+        >
+          전체
+        </Button>
+        <Button
+          type="button"
+          checked={selectedCategory === 1}
+          onClick={() => onClickCardinal(1)}
+        >
+          1기
+        </Button>
+        <Button
+          type="button"
+          checked={selectedCategory === 2}
+          onClick={() => onClickCardinal(2)}
+        >
+          2기
+        </Button>
+        <Button
+          type="button"
+          checked={selectedCategory === 3}
+          onClick={() => onClickCardinal(3)}
+        >
+          3기
+        </Button>
+        <Button
+          type="button"
+          checked={selectedCategory === 4}
+          onClick={() => onClickCardinal(4)}
+        >
+          4기
+        </Button>
+      </ScrollContainer>
     </StyledCategory>
   );
 };

--- a/src/components/MyPage/InfoInput.jsx
+++ b/src/components/MyPage/InfoInput.jsx
@@ -68,12 +68,13 @@ const InfoInput = ({
   const [passwordVisible, setPasswordVisible] = useState(false);
 
   const validateValue = (val) => {
+    if (val === '') return true; // 입력값이 비어있을 경우 유효하다고 판단
     const numberRegex = /^[0-9]*$/;
-    const koreanRegex = /[ㄱ-ㅎ|ㅏ-ㅣ|가-힣]/; // 한글 필터링 정규 표현식
+    const koreanRegex = /^[ㄱ-ㅎ가-힣]*$/; // 한글만 허용하는 정규 표현식
 
     switch (inputType) {
       case 'text':
-        return /^[가-힣a-zA-Z]*$/.test(val); // 한글/영어만
+        return koreanRegex.test(val) && val.length <= 5; // 한글만, 최대 5자리
       case 'number':
         if (text === '학번') {
           return numberRegex.test(val) && val.length <= 9; // 숫자만, 최대 9자리

--- a/src/pages/AttendCheck.jsx
+++ b/src/pages/AttendCheck.jsx
@@ -5,6 +5,7 @@ import AttendHeader from '../components/Attendance/AttendHeader';
 import AttendCheckMain from '../components/Attendance/AttendCheckMain';
 import { PenaltyProvider } from '../hooks/PenaltyContext';
 import AttendCheckAPI from '../hooks/AttendCheckAPI';
+import useCustomBack from '../router/useCustomBack';
 
 const Container = styled.div`
   display: flex;
@@ -23,6 +24,7 @@ const Footer = styled.footer`
 `;
 
 const AttendCheck = () => {
+  useCustomBack('/attendance');
   return (
     <ThemeProvider theme={theme}>
       <AttendCheckAPI />

--- a/src/pages/Attendance.jsx
+++ b/src/pages/Attendance.jsx
@@ -5,6 +5,7 @@ import AttendHeader from '../components/Attendance/AttendHeader';
 import AttendMain from '../components/Attendance/AttendMain';
 import { PenaltyProvider } from '../hooks/PenaltyContext';
 import { AttendProvider } from '../hooks/AttendContext';
+import useCustomBack from '../router/useCustomBack';
 
 const Container = styled.div`
   display: flex;
@@ -23,6 +24,7 @@ const Footer = styled.footer`
 `;
 
 const Attendance = () => {
+  useCustomBack('/home');
   return (
     <ThemeProvider theme={theme}>
       <AttendProvider>

--- a/src/pages/Calendar.jsx
+++ b/src/pages/Calendar.jsx
@@ -5,6 +5,7 @@ import CalendarHeader from '../components/Calendar/CalendarHeader';
 import MonthCalendar from '../components/Calendar/MonthCalendar';
 import YearCalendar from '../components/Calendar/YearCalendar';
 import ToggleButton from '../components/Calendar/ToggleButton';
+import useCustomBack from '../router/useCustomBack';
 
 const StyledCalendar = styled.div`
   width: 370px;
@@ -21,6 +22,7 @@ const todayYear = new Date().getFullYear();
 const todayMonth = new Date().getMonth() + 1;
 
 const Calendar = () => {
+  useCustomBack('/home');
   const [calendarType, setCalendarType] = useState('month');
   const [isYear, setIsYear] = useState(false);
   const [year, setYear] = useState(todayYear);

--- a/src/pages/Dues.jsx
+++ b/src/pages/Dues.jsx
@@ -7,6 +7,7 @@ import DuesInfo from '../components/Dues/DuesInfo';
 import DuesTitle from '../components/Dues/DuesTitle';
 import { DuesContext } from '../hooks/DuesContext';
 import DuesAPI from '../hooks/DuesAPI';
+import useCustomBack from '../router/useCustomBack';
 
 const StyledDues = styled.div`
   width: 370px;
@@ -58,6 +59,8 @@ const MoneyBox = styled.div`
 `;
 
 const Dues = () => {
+  useCustomBack('/home');
+
   const { duesData, totalAmount, currentAmount, myCardinal } =
     useContext(DuesContext);
   const [selected, setSelectedDues] = useState(null);

--- a/src/pages/Edit.jsx
+++ b/src/pages/Edit.jsx
@@ -1,5 +1,7 @@
 /* eslint-disable no-console */
 /* eslint-disable no-restricted-syntax */
+/* eslint-disable no-alert */
+
 import React, { useState, useContext, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
@@ -12,8 +14,7 @@ import InfoInput from '../components/MyPage/InfoInput';
 import DropdownMenu from '../components/DropdownMenu';
 
 import { UserContext } from '../hooks/UserContext';
-
-/* eslint-disable no-alert */
+import useCustomBack from '../router/useCustomBack';
 
 const StyledEdit = styled.div`
   width: 370px;
@@ -38,6 +39,8 @@ const Error = styled.div`
 `;
 
 const Edit = () => {
+  useCustomBack('/mypage');
+
   const { userData, error } = useContext(UserContext);
   const [userInfo, setUserInfo] = useState([]);
   const accessToken = localStorage.getItem('accessToken');

--- a/src/pages/Edit.jsx
+++ b/src/pages/Edit.jsx
@@ -75,7 +75,7 @@ const Edit = () => {
         return acc;
       }, {});
 
-      response = await axios.patch(`${BASE_URL}/users`, data, {
+      response = await axios.patch(`${BASE_URL}/api/v1/users`, data, {
         headers: {
           Authorization: `Bearer ${accessToken}`,
           Authorization_refresh: `Bearer ${refreshToken}`,
@@ -106,6 +106,7 @@ const Edit = () => {
         console.log(response);
         navi('/mypage');
       } else {
+        console.log(response);
         alert('서버 응답 오류/n저장 중 오류가 발생했습니다.');
       }
       console.log(response);

--- a/src/pages/EventAdmin.jsx
+++ b/src/pages/EventAdmin.jsx
@@ -11,6 +11,7 @@ import { replaceNewLines } from '../hooks/Utils';
 import { createEvent, editEvent } from '../hooks/EventAdminAPI';
 import EventInfoAPI from '../hooks/EventInfoAPI';
 import { EventInfoContext } from '../hooks/EventInfoContext';
+import useCustomBack from '../router/useCustomBack';
 
 const StyledCreate = styled.div`
   display: flex;
@@ -87,6 +88,8 @@ const ISOToArray = (isoString) => {
 };
 
 const EventAdmin = () => {
+  useCustomBack('/calendar');
+
   const { infoData, error } = useContext(EventInfoContext);
   console.log(error);
   const [eventInfo, setEventInfo] = useState([

--- a/src/pages/EventAdmin.jsx
+++ b/src/pages/EventAdmin.jsx
@@ -28,18 +28,39 @@ const DatePickerWrapper = styled.div`
   padding-top: 10px;
 `;
 
+const TextAreaWrapper = styled.div`
+  margin: 12px 10px;
+  width: 344px;
+  background-color: ${theme.color.grayScale.gray18};
+  border-radius: 4px;
+`;
+
 const StyledTextArea = styled.textarea`
   height: 504px;
+  width: 310px;
+  margin: 15px 10px;
+  padding-right: 10px;
   resize: none;
-  padding: 15px 10px;
-  margin: 12px 15px;
   border: none;
-  border-radius: 4px;
   outline: none;
   background-color: ${theme.color.grayScale.gray18};
   color: white;
   font-family: ${theme.font.family.pretendard_regular};
   font-size: 16px;
+
+  &::-webkit-scrollbar {
+    width: 5px;
+    margin: 15px 10px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: rgba(255, 255, 255, 0.5);
+    border-radius: 4px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
 `;
 
 const getTodayArr = () => {
@@ -296,11 +317,13 @@ const EventAdmin = () => {
         align="left"
         editValue={(value) => editValue('memberCount', value)}
       />
-      <StyledTextArea
-        placeholder="내용"
-        value={eventInfo.find((item) => item.key === 'content')?.value || ''}
-        onChange={(e) => editValue('content', e.target.value)}
-      />
+      <TextAreaWrapper>
+        <StyledTextArea
+          placeholder="내용"
+          value={eventInfo.find((item) => item.key === 'content')?.value || ''}
+          onChange={(e) => editValue('content', e.target.value)}
+        />
+      </TextAreaWrapper>
     </StyledCreate>
   );
 };

--- a/src/pages/EventDetails.jsx
+++ b/src/pages/EventDetails.jsx
@@ -9,6 +9,7 @@ import icClock from '../assets/images/ic_clock.svg';
 import theme from '../styles/theme';
 import BoardTitle from '../components/BoardTitle';
 import EventInfoAPI from '../hooks/EventInfoAPI';
+import useCustomBack from '../router/useCustomBack';
 
 const StyledEventDetails = styled.div`
   width: 370px;
@@ -44,6 +45,8 @@ const Line = styled.div`
 `;
 
 const EventDetails = () => {
+  useCustomBack('/calendar');
+
   const { id } = useParams();
   const [eventDetailData, setEventDetailData] = useState(null);
   const [error, setError] = useState(null);

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -6,6 +6,7 @@ import HomeFooter from '../components/home/HomeFooter';
 import LogoutButton from '../components/LogoutButton';
 import UserAPI from '../hooks/UserAPI';
 import logo from '../assets/images/ic_logo.svg';
+import useCustomBack from '../router/useCustomBack';
 
 const Container = styled.div`
   display: flex;
@@ -36,6 +37,8 @@ const Footer = styled.footer`
 `;
 
 const Home = () => {
+  useCustomBack('/home');
+
   const accessToken = localStorage.getItem('accessToken');
   const refreshToken = localStorage.getItem('refreshToken');
   // eslint-disable-next-line no-console

--- a/src/pages/Landing.jsx
+++ b/src/pages/Landing.jsx
@@ -4,6 +4,7 @@ import styled, { ThemeProvider } from 'styled-components';
 import theme from '../styles/theme';
 import Button from '../components/Button/Button';
 import leets from '../assets/images/ic_name_logo.svg';
+import useCustomBack from '../router/useCustomBack';
 
 /* 높이를 810px로 잡고 각각의 margin을 px로 잡았습니다 */
 
@@ -40,6 +41,8 @@ const LoginButton = styled(Button)`
 `;
 
 const Landing = () => {
+  useCustomBack('/');
+
   const [signupClicked, setSignupClicked] = useState(false);
   const [loginClicked, setLoginClicked] = useState(false);
   const navi = useNavigate();

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -7,6 +7,7 @@ import SignupTextComponent from '../components/Signup/SignupTextComponent';
 import { ReactComponent as ToggleVisibleIcon } from '../assets/images/ic_toggleVisible.svg';
 import { ReactComponent as ToggleInvisibleIcon } from '../assets/images/ic_toggleInvisible.svg';
 import Utils from '../hooks/Utils';
+import useCustomBack from '../router/useCustomBack';
 
 const Container = styled.div`
   display: flex;
@@ -34,6 +35,8 @@ const ErrorMessage = styled.div`
 `;
 
 const Login = () => {
+  useCustomBack('/');
+
   const navigate = useNavigate();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');

--- a/src/pages/Member.jsx
+++ b/src/pages/Member.jsx
@@ -7,6 +7,7 @@ import Category from '../components/Member/Category';
 import MemberName from '../components/Member/MemberName';
 // import mockUser from '../components/mockData/mockUser';
 import { UserContext } from '../hooks/UserContext';
+import useCustomBack from '../router/useCustomBack';
 
 const StyledMember = styled.div`
   width: 370px;
@@ -36,6 +37,8 @@ const Error = styled.div`
 `;
 
 const Member = () => {
+  useCustomBack('/home');
+
   const [selectedCardinal, setSelectedCardinal] = useState(0);
 
   const { allUserData, error } = useContext(UserContext);

--- a/src/pages/Member.jsx
+++ b/src/pages/Member.jsx
@@ -14,7 +14,7 @@ const StyledMember = styled.div`
 `;
 
 const CategoryWrapper = styled.div`
-  margin: 0 30px;
+  margin-left: 30px;
 `;
 
 const MemberList = styled.div`

--- a/src/pages/MemberDetail.jsx
+++ b/src/pages/MemberDetail.jsx
@@ -10,6 +10,7 @@ import icDepartment from '../assets/images/ic_department.svg';
 import icCardinal from '../assets/images/ic_cardinal.svg';
 import icPosition from '../assets/images/ic_position.svg';
 import icEmail from '../assets/images/ic_mail.svg';
+import useCustomBack from '../router/useCustomBack';
 
 const StyledDetails = styled.div`
   width: 370px;
@@ -22,6 +23,7 @@ const InfoWrapper = styled.div`
 `;
 
 const UserDetail = () => {
+  useCustomBack('/member');
   const location = useLocation();
   const { name, studentId, department, email, cardinal, position } =
     location.state;

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -19,6 +19,7 @@ import icEdit from '../assets/images/ic_edit.svg';
 import icLogout from '../assets/images/ic_logout_white.svg';
 import { UserContext } from '../hooks/UserContext';
 import UserAPI from '../hooks/UserAPI';
+import handleLogout from '../utils/handleLogout';
 
 import theme from '../styles/theme';
 
@@ -77,6 +78,7 @@ const LogoutButton = styled.button`
   border-radius: 10px;
   color: white;
   background-color: ${theme.color.grayScale.gray30};
+  cursor: pointer;
 `;
 
 const MyPage = () => {
@@ -87,6 +89,7 @@ const MyPage = () => {
 
   const BASE_URL = process.env.REACT_APP_BASE_URL;
 
+  const confirmLogout = handleLogout();
   const onClickLeave = async () => {
     if (window.confirm('탈퇴하시겠습니까?')) {
       try {
@@ -103,8 +106,6 @@ const MyPage = () => {
       }
     }
   };
-
-  const onClickLogout = () => {};
 
   return (
     <StyledDetails>
@@ -167,7 +168,7 @@ const MyPage = () => {
       </ImgButton>
       <Account>
         <LeaveButton onClick={onClickLeave}>탈퇴하기</LeaveButton>
-        <LogoutButton onClick={onClickLogout}>
+        <LogoutButton onClick={confirmLogout}>
           <img src={icLogout} alt="로그아웃" />
           <div>로그아웃</div>
         </LogoutButton>

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -20,7 +20,7 @@ import icLogout from '../assets/images/ic_logout_white.svg';
 import { UserContext } from '../hooks/UserContext';
 import UserAPI from '../hooks/UserAPI';
 import handleLogout from '../utils/handleLogout';
-
+import useCustomBack from '../router/useCustomBack';
 import theme from '../styles/theme';
 
 /* eslint-disable no-alert */
@@ -82,6 +82,7 @@ const LogoutButton = styled.button`
 `;
 
 const MyPage = () => {
+  useCustomBack('/home');
   const { userData, error } = useContext(UserContext);
   const navi = useNavigate();
   const accessToken = localStorage.getItem('accessToken');

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -7,6 +7,7 @@ import SignupMemInput from '../components/Signup/SignupMemInput';
 import SignupHeader from '../components/Signup/SignupHeader';
 import RoleSector from '../components/Signup/RoleSector';
 import SignupDropDown from '../components/Signup/SignupDropDown';
+import useCustomBack from '../router/useCustomBack';
 
 const ProfileContainer = styled.div`
   width: 370px;
@@ -37,6 +38,8 @@ const roleMapping = {
 };
 
 const Profile = () => {
+  useCustomBack('/signup');
+
   const location = useLocation();
   const navigate = useNavigate();
   const { email, password } = location.state || { email: '', password: '' };

--- a/src/pages/Receipt.jsx
+++ b/src/pages/Receipt.jsx
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import AttendHeader from '../components/Attendance/AttendHeader';
 import ReceiptMain from '../components/Receipt/ReceiptMain';
 import { DuesProvider } from '../hooks/DuesContext';
+import useCustomBack from '../router/useCustomBack';
 
 const Container = styled.div`
   display: flex;
@@ -12,6 +13,8 @@ const Container = styled.div`
 `;
 
 const Receipt = () => {
+  useCustomBack('/dues');
+
   return (
     <DuesProvider>
       <Container>

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -7,6 +7,7 @@ import SignupTextComponent from '../components/Signup/SignupTextComponent';
 import { ReactComponent as ToggleVisibleIcon } from '../assets/images/ic_toggleVisible.svg';
 import { ReactComponent as ToggleInvisibleIcon } from '../assets/images/ic_toggleInvisible.svg';
 import theme from '../styles/theme';
+import useCustomBack from '../router/useCustomBack';
 
 const Container = styled.div`
   display: flex;
@@ -69,6 +70,8 @@ const ToggleVisibilityButton = styled.button`
 `;
 
 const Signup = () => {
+  useCustomBack('/');
+
   const navi = useNavigate();
 
   const [page, setPage] = useState(0);

--- a/src/router/useCustomBack.jsx
+++ b/src/router/useCustomBack.jsx
@@ -1,0 +1,39 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+/*
+사용방법!!
+각 페이지의 임포트 후 컴포넌트 최상단에서 사용
+매개변수로 뒤로가기 시 이동할 페이지의 경로를 적어주면 됨!!
+
+아래는 예시..
+
+cosnt Example = () => {
+  useCustomBack('/');
+  return ();
+}
+*/
+
+const useCustomBack = (redirectPath) => {
+  const navigate = useNavigate();
+
+  const browserPreventEvent = () => {
+    window.history.pushState(null, '', window.location.href);
+    navigate(redirectPath);
+  };
+
+  useEffect(() => {
+    const handlePopstate = () => {
+      browserPreventEvent();
+    };
+
+    window.history.pushState(null, '', window.location.href);
+    window.addEventListener('popstate', handlePopstate);
+
+    return () => {
+      window.removeEventListener('popstate', handlePopstate);
+    };
+  }, [navigate, redirectPath]);
+};
+
+export default useCustomBack;


### PR DESCRIPTION
## 1. 개발내용
많은 것들을 수정..~

## 2. 구현 세부사항

### 내 정보 수정 오류 해결
- api 도메인 수정
- 드롭다운 수정
- 이름 입력제한 - 한글 5글자 이내

### 일정 생성/수정 스크롤바 추가
![image](https://github.com/user-attachments/assets/ed3e837b-5010-47ff-b2b6-fffe6fe748c9)
- textarea에서는 스크롤바 마진을 설정할 수 없어서,, div태그를 하나 더 감싸서 영역 조절 후 여백 구현했습니당

### 뒤로가기 제한
원래 문제점 : 수정 페이지의 경우 뒤로가기 시 홈이 아닌 수정페이지로 돌아가는 이슈,,
브라우저 히스토리는 방문한 대로 저장이 되니까,,, 홈 > 마이페이지 > 수정 > 마이페이지 이런식으로 저장이 돼서 수정 후 뒤로가기를 하면? 당연히 직전 페이지인 수정으로 넘어가겠죠! 이러면 안되는데!...ㅜㅜ

하여튼 뒤로가기에 이런 문제가 있었는데요,, 원래 그냥 navigate하는 hook을 사용하려했지만,, `브라우저 자체의 뒤로가기를 사용하는 경우는 어떻게 제한함?` 이라는 큰 이슈가,,,,
있었지만,,,,
`useCustomBack`을 이용하여 브라우저 뒤로가기를 제어할 수 있게 됐습니다,,,

뒤로가기 사용시 원하는 경로로 리다이렉트를 하는 hook이에요 ^___^
각각의 페이지에서 import 후 매개변수로 원하는 경로를 입력해주면 댑니다,,

### 마이페이지 로그아웃 추가
- 온클릭함수로 설정이 안 되어있어서 추가했습니다..~

## 3. 메모
뒤로가기를 모든 페이지에 설정했는데 게시판은 confilct 날 것 같아서 일단 냅뒀어용,,