### PR TITLE
#216 fix: util 수정

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -59,7 +59,6 @@ const App = () => {
       <NoticeProvider>
       <YearlyScheduleProvider>
       <AttendCheckProvider>
-      <UserAPI />
       <MonthlyScheduleAPI />
       <ScrollToTop />
         <Routes>

--- a/src/components/Attendance/AttendCheckMain.jsx
+++ b/src/components/Attendance/AttendCheckMain.jsx
@@ -183,12 +183,10 @@ const AttendCheckMain = () => {
     return <div>Loading...</div>;
   }
 
-  const { userData, error } = useContext(UserContext);
+  const { userData } = useContext(UserContext);
 
   let userName;
-  if (error) {
-    userName = 'error';
-  } else if (!userData) {
+  if (!userData) {
     userName = 'loading';
   } else {
     userName = userData.name;
@@ -240,7 +238,6 @@ const AttendCheckMain = () => {
 
             const formattedDate = `${startDateTime} (${startTime} ~ ${endTime})`;
 
-            console.log(meeting.status);
             return (
               <MeetingBox
                 key={meeting.id}

--- a/src/components/Attendance/AttendMain.jsx
+++ b/src/components/Attendance/AttendMain.jsx
@@ -99,12 +99,10 @@ const AttendMain = () => {
   const [shouldFetchData, setShouldFetchData] = useState(false);
   const [hasPenalty, setHasPenalty] = useState(false);
 
-  const { userData, error } = useContext(UserContext);
+  const { userData } = useContext(UserContext);
 
   let userName;
-  if (error) {
-    userName = 'error';
-  } else if (!userData) {
+  if (!userData) {
     userName = 'loading';
   } else {
     userName = userData.name;

--- a/src/components/home/HomeMain.jsx
+++ b/src/components/home/HomeMain.jsx
@@ -12,8 +12,6 @@ import calendar from '../../assets/images/ic_home_calendar.svg';
 import attend from '../../assets/images/ic_home_attend.svg';
 import board from '../../assets/images/ic_home_board.svg';
 
-import UserAPI from '../../hooks/UserAPI';
-
 const StyledHomeMain = styled.div`
   display: flex;
   flex-direction: column;
@@ -102,7 +100,6 @@ const HomeMain = () => {
 
   return (
     <StyledHomeMain>
-      <UserAPI />
       <CaptionContainer>
         <Caption color="#ffffff" textColor="#000000">
           3기

--- a/src/hooks/DuesAPI.jsx
+++ b/src/hooks/DuesAPI.jsx
@@ -44,7 +44,7 @@ const DuesAPI = () => {
             setCardinal(result.data.cardinal);
             setCurrentAmount(result.data.currentAmount);
             setTime(result.data.time);
-            console.log(result);
+            // console.log(result);
           }
         } else {
           console.error('Failed to get data:', result.message);

--- a/src/hooks/DuesAPI.jsx
+++ b/src/hooks/DuesAPI.jsx
@@ -50,7 +50,13 @@ const DuesAPI = () => {
           console.error('Failed to get data:', result.message);
         }
       } catch (error) {
-        console.error('Error getting data:', error);
+        // 무한 리다이렉션 방지
+        if (window.location.pathname !== '/login') {
+          console.error('An error occurred while fetching the data');
+          localStorage.removeItem('accessToken');
+          localStorage.removeItem('refreshToken');
+          window.location.href = '/login';
+        }
       }
     };
 

--- a/src/hooks/DuesAPI.jsx
+++ b/src/hooks/DuesAPI.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useContext } from 'react';
 import axios from 'axios';
 import { DuesContext } from './DuesContext';
+import Utils from './Utils';
 
 const DuesAPI = () => {
   const {
@@ -14,7 +15,6 @@ const DuesAPI = () => {
 
   const accessToken = localStorage.getItem('accessToken');
   const refreshToken = localStorage.getItem('refreshToken');
-
   useEffect(() => {
     const fetchDuesData = async () => {
       try {
@@ -25,12 +25,14 @@ const DuesAPI = () => {
         };
         const BASE_URL = process.env.REACT_APP_BASE_URL;
 
-        // 비동기 요청에 await 추가
-        const response = await axios.get(
-          `${BASE_URL}/api/v1/account/${cardinal}`,
-          {
-            headers,
-          },
+        const originalApiFunc = (funcCardinal) =>
+          axios.get(`${BASE_URL}/api/v1/account/${funcCardinal}`, { headers });
+
+        // API 호출을 Utils로 처리
+        const response = await Utils(
+          await originalApiFunc(cardinal),
+          originalApiFunc,
+          [cardinal],
         );
 
         const result = response.data;

--- a/src/hooks/UserAPI.jsx
+++ b/src/hooks/UserAPI.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useContext } from 'react';
 import axios from 'axios';
 import { UserContext } from './UserContext';
+import Utils from './Utils'; // Utils 함수 임포트
 
 const UserAPI = () => {
   const { setUserData, setError, setAllUserData } = useContext(UserContext);
@@ -15,35 +16,57 @@ const UserAPI = () => {
       Authorization_refresh: `Bearer ${refreshToken}`,
     };
 
-    // 내 정보 조회
-    axios
-      .get(`${BASE_URL}/api/v1/users`, { headers })
-      .then((response) => {
-        if (response.data.code === 200) {
-          setUserData(response.data.data);
+    const fetchUserData = async () => {
+      try {
+        // 내 정보 조회 API 호출 함수
+        const originalApiFuncUser = () =>
+          axios.get(`${BASE_URL}/api/v1/users`, { headers });
+
+        // Utils 함수로 처리
+        const userResponse = await Utils(
+          await originalApiFuncUser(),
+          originalApiFuncUser,
+          [],
+        );
+
+        if (userResponse.data.code === 200) {
+          setUserData(userResponse.data.data);
         } else {
-          setError(response.data.message);
+          setError(userResponse.data.message);
         }
-      // console.log('유저 api 받아옴!', response.data.data);
-      })
-      .catch((err) => {
+      } catch (err) {
         setError('An error occurred while fetching the data');
-      });
+      }
+    };
 
-      // 모든 멤버 조회
-      axios.get(`${BASE_URL}/api/v1/users/all`, { headers })
-      .then((response) => {
-        if (response.data.code === 200) {
-          setAllUserData(response.data.data);
+    const fetchAllUsersData = async () => {
+      try {
+        // 모든 멤버 조회 API 호출 함수
+        const originalApiFuncAllUsers = () =>
+          axios.get(`${BASE_URL}/api/v1/users/all`, { headers });
+
+        // Utils 함수로 처리
+        const allUsersResponse = await Utils(
+          await originalApiFuncAllUsers(),
+          originalApiFuncAllUsers,
+          [],
+        );
+
+        if (allUsersResponse.data.code === 200) {
+          setAllUserData(allUsersResponse.data.data);
         } else {
-          setError(response.data.message);
+          setError(allUsersResponse.data.message);
         }
-      })
-      .catch((err) => {
+      } catch (err) {
         setError('An error occurred while fetching the all users data');
-      });
+      }
+    };
 
-  }, [accessToken, setUserData, setError, setAllUserData]);
+    // 내 정보 조회 및 모든 멤버 조회 비동기 함수 호출
+    fetchUserData();
+    fetchAllUsersData();
+
+  }, [accessToken, setUserData, setError, setAllUserData, BASE_URL]);
 
   return null;
 };

--- a/src/hooks/UserAPI.jsx
+++ b/src/hooks/UserAPI.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useContext } from 'react';
 import axios from 'axios';
 import { UserContext } from './UserContext';
-import Utils from './Utils'; // Utils 함수 임포트
+import Utils from './Utils';
 
 const UserAPI = () => {
   const { setUserData, setError, setAllUserData } = useContext(UserContext);
@@ -18,15 +18,13 @@ const UserAPI = () => {
 
     const fetchUserData = async () => {
       try {
-        // 내 정보 조회 API 호출 함수
         const originalApiFuncUser = () =>
           axios.get(`${BASE_URL}/api/v1/users`, { headers });
 
-        // Utils 함수로 처리
         const userResponse = await Utils(
           await originalApiFuncUser(),
           originalApiFuncUser,
-          [],
+          []
         );
 
         if (userResponse.data.code === 200) {
@@ -35,21 +33,25 @@ const UserAPI = () => {
           setError(userResponse.data.message);
         }
       } catch (err) {
-        setError('An error occurred while fetching the data');
+        // 무한 리다이렉션 방지
+        if (window.location.pathname !== '/login') {
+          setError('An error occurred while fetching the data');
+          localStorage.removeItem('accessToken');
+          localStorage.removeItem('refreshToken');
+          window.location.href = '/login';
+        }
       }
     };
 
     const fetchAllUsersData = async () => {
       try {
-        // 모든 멤버 조회 API 호출 함수
         const originalApiFuncAllUsers = () =>
           axios.get(`${BASE_URL}/api/v1/users/all`, { headers });
 
-        // Utils 함수로 처리
         const allUsersResponse = await Utils(
           await originalApiFuncAllUsers(),
           originalApiFuncAllUsers,
-          [],
+          []
         );
 
         if (allUsersResponse.data.code === 200) {
@@ -58,14 +60,18 @@ const UserAPI = () => {
           setError(allUsersResponse.data.message);
         }
       } catch (err) {
-        setError('An error occurred while fetching the all users data');
+        // 무한 리다이렉션 방지
+        if (window.location.pathname !== '/login') {
+          setError('An error occurred while fetching the data');
+          localStorage.removeItem('accessToken');
+          localStorage.removeItem('refreshToken');
+          window.location.href = '/login';
+        }
       }
     };
 
-    // 내 정보 조회 및 모든 멤버 조회 비동기 함수 호출
     fetchUserData();
     fetchAllUsersData();
-
   }, [accessToken, setUserData, setError, setAllUserData, BASE_URL]);
 
   return null;

--- a/src/hooks/Utils.js
+++ b/src/hooks/Utils.js
@@ -1,24 +1,30 @@
-const Utils = async (response, originalApiFunc, originalParams, navigate) => {
-  // 데이터가 비어있는지 확인(데이터가 null/undefined, 객체, 배열일 때를 확인)
+const Utils = async (response, originalApiFunc, originalParams) => {
+  // 데이터가 비어있는지 확인
   const isResponseBodyEmpty = (data) => {
-    if (data === null || data === undefined) return true;
+    if (data === null || data === undefined || data=='') {
+      return true;
+    };
     if (typeof data === 'object') return Object.keys(data).length === 0;
     if (Array.isArray(data)) return data.length === 0;
     return false;
   };
+  console.log('utils 코드', response.status);
 
   if (response.status === 200) {
+    // Body가 비어 있지 않으면 데이터를 반환
+    // console.log('utils',isResponseBodyEmpty(response.data));
+    // console.log('utils.data', response.data);
     if (!isResponseBodyEmpty(response.data)) {
-      const newToken = response.headers['authorization'];
-      const newRefreshToken = response.headers['authorization-refresh'];
-      // alert('login token', newToken, newRefreshToken);
+      // console.log(response);
       return response;
     } else {
-      // Body가 비어있으면 token, refresh tokens을 local storage에 저장하기
-      const newToken = response.headers['authorization'];
-      const newRefreshToken = response.headers['authorization-refresh'];
-      console.log('login token', newToken, newRefreshToken);
-      // 새 토큰, refreshToken 둘 다 있는지
+      // Body가 비어있다면 새로운 토큰이 있는지 확인하고, 로컬 스토리지에 저장
+      console.log('utils.header', response);
+      localStorage.removeItem('accessToken');
+      localStorage.removeItem('refreshToken');
+      const newToken = response.headers.authorization;
+      const newRefreshToken = response.headers.authorization_refresh;
+      console.log(newToken, newRefreshToken);
       if (newToken && newRefreshToken) {
         localStorage.setItem('accessToken', newToken);
         localStorage.setItem('refreshToken', newRefreshToken);
@@ -30,12 +36,14 @@ const Utils = async (response, originalApiFunc, originalParams, navigate) => {
         throw new Error('새 토큰이 없습니다');
       }
     }
-  } else {
-    // local Storage 비우고 로그인 화면으로 리다이렉트
+  } else if (response.status === 403) {
+    // 403 상태 코드일 경우 토큰이 만료되었으므로 로컬 스토리지를 비우고 로그인 페이지로 리다이렉트
     localStorage.removeItem('accessToken');
     localStorage.removeItem('refreshToken');
-    navigate('/login');
-    throw new Error('Forbidden : 로그인 화면으로 리디렉션합니다.');
+    window.location.href = '/login';
+    throw new Error('Forbidden: 로그인 화면으로 리디렉션합니다.');
+  } else {
+    throw new Error(`Unexpected status code: ${response.status}`);
   }
 };
 

--- a/src/hooks/Utils.js
+++ b/src/hooks/Utils.js
@@ -20,8 +20,6 @@ const Utils = async (response, originalApiFunc, originalParams) => {
     } else {
       // Body가 비어있다면 새로운 토큰이 있는지 확인하고, 로컬 스토리지에 저장
       console.log('utils.header', response);
-      localStorage.removeItem('accessToken');
-      localStorage.removeItem('refreshToken');
       const newToken = response.headers.authorization;
       const newRefreshToken = response.headers.authorization_refresh;
       console.log(newToken, newRefreshToken);

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -39,10 +39,9 @@ const Footer = styled.footer`
 const Home = () => {
   useCustomBack('/home');
 
-  const accessToken = localStorage.getItem('accessToken');
-  const refreshToken = localStorage.getItem('refreshToken');
-  // eslint-disable-next-line no-console
-  console.log('home token', accessToken, refreshToken);
+  // const accessToken = localStorage.getItem('accessToken');
+  // const refreshToken = localStorage.getItem('refreshToken');
+  // console.log('home token', accessToken, refreshToken);
   return (
     <ThemeProvider theme={theme}>
       <UserAPI />

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -7,7 +7,6 @@ import LoginHeader from '../components/Login/LoginHeader';
 import SignupTextComponent from '../components/Signup/SignupTextComponent';
 import { ReactComponent as ToggleVisibleIcon } from '../assets/images/ic_toggleVisible.svg';
 import { ReactComponent as ToggleInvisibleIcon } from '../assets/images/ic_toggleInvisible.svg';
-import Utils from '../hooks/Utils';
 import useCustomBack from '../router/useCustomBack';
 import theme from '../styles/theme';
 
@@ -95,17 +94,11 @@ const Login = () => {
       const BASE_URL = process.env.REACT_APP_BASE_URL;
       const response = await axios.post(`${BASE_URL}/api/v1/login`, params);
 
-      const validatedResponse = await Utils(
-        response,
-        axios.post,
-        [params],
-        navigate,
-      );
-
-      if (validatedResponse.status === 200) {
+      if (response.status === 200) {
         setError(null);
+        // console.log(response);
         const newToken = response.headers.authorization;
-        const newRefreshToken = response.headers['authorization-refresh'];
+        const newRefreshToken = response.headers.authorization_refresh;
         localStorage.setItem('accessToken', newToken);
         localStorage.setItem('refreshToken', newRefreshToken);
         console.log('login token', newToken, newRefreshToken);


### PR DESCRIPTION
## 설명
서버를 열심히 괴롭히며.. 하루를 쏟아부어,, 토큰 유효성 검사 거의? 완료 했습니당

## 구조
**1. 액세스 토큰 유효/ 리프레시 토큰 유효**
서버: status 200, body에 data 담아줌
프론트: Utils.js에서 body data 있나 확인 후 있으면 걍 사용 

**2. 액세스 토큰 만료/ 리프레시 토큰 유효**
서버: status 200, body 비어있음
프론트: Utils.js에서 body가 비어있으면 새로 토큰을 저장하고 해당 api를 재 실행함

**3. 액세스 토큰 만료/ 리프레시 토큰 만료**
서버: status 403
프론트: 이 때는 Utils.js 실행하지 않고 api componenet(예시: UserAPI)에서 에러를 catch 하여  로그인 페이지로 리다이렉션 함

현재 api component에서 catch 구문에 로그인 리다이렉션 구현한 건 UserAPI와 DuesAPI입니다. UserAPI를 사용하지 않는 페이지가 있다면 알려주세요! 해당 페이지에서 사용하는 api에 로그인 리다이렉션 추가가 필요합니다. 

++ 현재 액세스 토큰 유효기간 5분 리프레시는 3분이라 로그인 하고 3분 지나면 로그인 페이지로 리다이렉션 됩니다ㅎ.ㅎ
