### PR TITLE
[fix] 회비 사용내역:  운영진이 입력한 내용이 뜨도록 수정

### DIFF
--- a/src/hooks/DuesAPI.jsx
+++ b/src/hooks/DuesAPI.jsx
@@ -7,6 +7,7 @@ const DuesAPI = () => {
   const {
     myCardinal,
     setDuesData,
+    setDescription,
     setTotalAmount,
     setCurrentAmount,
     setCardinal,
@@ -40,6 +41,7 @@ const DuesAPI = () => {
         if (result.code === 200) {
           if (result.data.cardinal !== myCardinal) {
             setDuesData(result.data.receipts);
+            setDescription(result.data.description);
             setTotalAmount(result.data.totalAmount);
             setCardinal(result.data.cardinal);
             setCurrentAmount(result.data.currentAmount);

--- a/src/hooks/DuesContext.js
+++ b/src/hooks/DuesContext.js
@@ -7,6 +7,7 @@ export const DuesContext = createContext();
 // eslint-disable-next-line react/prop-types
 export const DuesProvider = ({ children }) => {
   const [duesData, setDuesData] = useState([]);
+  const [description, setDescription] = useState('');
   const [totalAmount, setTotalAmount] = useState(0);
   const [currentAmount, setCurrentAmount] = useState(0);
   const [time, setTime] = useState('');
@@ -17,6 +18,8 @@ export const DuesProvider = ({ children }) => {
       value={{
         duesData,
         setDuesData,
+        description,
+        setDescription,
         totalAmount,
         setTotalAmount,
         currentAmount,

--- a/src/pages/Dues.jsx
+++ b/src/pages/Dues.jsx
@@ -61,8 +61,9 @@ const MoneyBox = styled.div`
 const Dues = () => {
   useCustomBack('/home');
 
-  const { duesData, totalAmount, currentAmount, myCardinal } =
+  const { duesData, description, totalAmount, currentAmount, myCardinal } =
     useContext(DuesContext);
+  console.log(duesData);
   const [selected, setSelectedDues] = useState(null);
 
   const filteredDues =
@@ -99,7 +100,7 @@ const Dues = () => {
                 dues={totalAmount}
                 category="회비" // 회비
                 date="2024-04-01"
-                memo={`${myCardinal}기 회비 등록`}
+                memo={description}
               />
             )}
             {/* 지출 항목들 */}


### PR DESCRIPTION
어드민 페이지에서 입력한 회비 설명이 유저에게도 보여지도록 수정했습니다

<img width="518" alt="스크린샷 2024-09-27 오후 5 21 39" src="https://github.com/user-attachments/assets/f97de08a-678b-478f-9d70-90773477f77c">
