### PR TITLE
#247 refactor: styled component 분리 (캘린더, 멤버, 마이페이지)

### DIFF
--- a/src/components/Calendar/CalendarHeader.tsx
+++ b/src/components/Calendar/CalendarHeader.tsx
@@ -1,15 +1,15 @@
+import React, { useContext, useState } from 'react';
 import Modal from 'react-modal';
-import React, { useState, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import LeftButton from '@/components/Header/LeftButton';
 import ModalMonthContent from '@/components/Calendar/ModalMonthContent';
+import LeftButton from '@/components/Header/LeftButton';
 import { UserContext } from '@/service/UserContext';
-import * as S from '@/styles/calendar/CalendarHeader.styled'
+import * as S from '@/styles/calendar/CalendarHeader.styled';
 import { monthModalStyles } from '@/styles/calendar/CalendarHeader.styled';
 
-import under from '@/assets/images/ic_under.svg';
 import icPlus from '@/assets/images/ic_plus.svg';
+import under from '@/assets/images/ic_under.svg';
 
 Modal.setAppElement('#root');
 
@@ -21,7 +21,13 @@ interface CalendarHeaderProps {
   editMonth: (newMonth: number) => void;
 }
 
-const CalendarHeader: React.FC<CalendarHeaderProps> = ({ month, year, isMonth, editYear, editMonth }) => {
+const CalendarHeader: React.FC<CalendarHeaderProps> = ({
+  month,
+  year,
+  isMonth,
+  editYear,
+  editMonth,
+}) => {
   const [monthModalIsOpen, setMonthModalIsOpen] = useState(false);
   const { userData, error } = useContext(UserContext);
   const navi = useNavigate();

--- a/src/components/Calendar/CalendarHeader.tsx
+++ b/src/components/Calendar/CalendarHeader.tsx
@@ -1,12 +1,12 @@
-import styled from 'styled-components';
 import Modal from 'react-modal';
 import React, { useState, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import theme from '@/styles/theme';
 import LeftButton from '@/components/Header/LeftButton';
 import ModalMonthContent from '@/components/Calendar/ModalMonthContent';
 import { UserContext } from '@/service/UserContext';
+import * as S from '@/styles/calendar/CalendarHeader.styled'
+import { monthModalStyles } from '@/styles/calendar/CalendarHeader.styled';
 
 import under from '@/assets/images/ic_under.svg';
 import icPlus from '@/assets/images/ic_plus.svg';
@@ -20,62 +20,6 @@ interface CalendarHeaderProps {
   editYear: (newYear: number) => void;
   editMonth: (newMonth: number) => void;
 }
-
-const StyledHeader = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin: 25px 25px 20px 25px; //기본 헤더 마진
-`;
-
-const TitleWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
-`;
-
-const TitleYear = styled.div`
-  font-size: 18px;
-  font-family: ${theme.font.family.pretendard_semiBold};
-  padding-right: 5px;
-`;
-
-const TitleMonth = styled.div`
-  font-size: 18px;
-  font-family: ${theme.font.family.pretendard_semiBold};
-`;
-
-const ImgButton = styled.div`
-  display: flex;
-  justify-content: flex-end;
-  margin: 5px;
-  cursor: pointer;
-`;
-
-const PlusButton = styled.img`
-  cursor: pointer;
-`;
-
-const monthModalStyles = {
-  overlay: {
-    backgroundColor: 'rgba(0,0,0,0.5)',
-    backdropFilter: 'blur(5px)', // 표준 CSS 속성
-    WebkitBackdropFilter: 'blur(5px)', // -webkit- 접두사를 사용한 속성
-    zIndex: 1000,
-    width: '100%',
-    height: '100%',
-    top: '10px',
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'flex-start',
-    margin: '55px auto', // 블러가 시작되는 위치를 정하고
-  },
-  content: {
-    margin: '10px auto', // 모달은 블러 시작점으로부터 10px 떨어진 곳에 위치
-  },
-};
 
 const CalendarHeader: React.FC<CalendarHeaderProps> = ({ month, year, isMonth, editYear, editMonth }) => {
   const [monthModalIsOpen, setMonthModalIsOpen] = useState(false);
@@ -106,7 +50,7 @@ const CalendarHeader: React.FC<CalendarHeaderProps> = ({ month, year, isMonth, e
   // userData를 잘 받아왔고, 해당 user의 role이 ADMIN이라면 어드민 버튼 렌더링
   else if (userData.role === 'ADMIN' && !monthModalIsOpen) {
     adminButton = (
-      <PlusButton
+      <S.PlusButton
         src={icPlus}
         alt="+"
         onClick={() => {
@@ -117,15 +61,15 @@ const CalendarHeader: React.FC<CalendarHeaderProps> = ({ month, year, isMonth, e
   }
 
   return (
-    <StyledHeader>
+    <S.StyledHeader>
       <LeftButton />
-      <TitleWrapper>
-        <TitleYear>{year}년</TitleYear>
-        <TitleMonth>{isMonth ? `${month}월` : null}</TitleMonth>
-        <ImgButton onClick={openMonthModal}>
+      <S.TitleWrapper>
+        <S.TitleYear>{year}년</S.TitleYear>
+        <S.TitleMonth>{isMonth ? `${month}월` : null}</S.TitleMonth>
+        <S.ImgButton onClick={openMonthModal}>
           <img src={under} alt="select" />
-        </ImgButton>
-      </TitleWrapper>
+        </S.ImgButton>
+      </S.TitleWrapper>
       {adminButton}
       <Modal
         className="calendar-modal"
@@ -142,7 +86,7 @@ const CalendarHeader: React.FC<CalendarHeaderProps> = ({ month, year, isMonth, e
           editMonth={editMonth}
         />
       </Modal>
-    </StyledHeader>
+    </S.StyledHeader>
   );
 };
 

--- a/src/components/Calendar/DateInput.tsx
+++ b/src/components/Calendar/DateInput.tsx
@@ -1,8 +1,7 @@
 /* eslint-disable no-alert */
 /* eslint-disable react/require-default-props */
 import { useState, useEffect } from 'react';
-import styled from 'styled-components';
-import theme from '@/styles/theme';
+import * as S from "@/styles/calendar/DateInput.styled";
 
 interface DateInputProps {
   type?: string;
@@ -15,33 +14,6 @@ interface DateInputProps {
   month?: number;
   inputType: 'year' | 'month' | 'day' | 'hour' | 'minute'
 }
-
-const StyledInput = styled.input<{ $height: string, $width: string, $margin: string }>`
-  height: ${(props) => props.$height || '0px'};
-  width: ${(props) => props.$width || '0px'};
-  outline: none;
-  border: none;
-  border-radius: 4px;
-  background-color: ${theme.color.grayScale.gray12};
-  color: white;
-  text-align: center;
-  margin-left: ${(props) => props.$margin || '0px'};
-  margin-right: ${(props) => props.$margin || '0px'};
-  padding: 0px;
-  font-size: 16px;
-  font-family: ${theme.font.family.pretendard_regular};
-
-  /* Custom CSS to remove arrows in number input */
-  /* Chrome, Safari, Edge, Opera */
-  &::-webkit-outer-spin-button,
-  &::-webkit-inner-spin-button {
-    -webkit-appearance: none;
-    margin: 0;
-  }
-
-  /* Firefox */
-  -moz-appearance: textfield;
-`;
 
 const getMaxDaysInMonth = (year: number, month: number) => {
   return new Date(year, month, 0).getDate();
@@ -136,7 +108,7 @@ const DateInput: React.FC<DateInputProps> = ({
 
   return (
     <div>
-      <StyledInput
+      <S.StyledInput
         type="number"
         value={date}
         onChange={onChangeValue}

--- a/src/components/Calendar/DateInput.tsx
+++ b/src/components/Calendar/DateInput.tsx
@@ -1,18 +1,17 @@
 /* eslint-disable no-alert */
-/* eslint-disable react/require-default-props */
-import { useState, useEffect } from 'react';
-import * as S from "@/styles/calendar/DateInput.styled";
+import * as S from '@/styles/calendar/DateInput.styled';
+import { useEffect, useState } from 'react';
 
 interface DateInputProps {
   type?: string;
   value?: string | number;
-  onChange: (value: string | number ) => void;
+  onChange: (value: string | number) => void;
   width: string;
   height: string;
   margin: string;
   year?: number;
   month?: number;
-  inputType: 'year' | 'month' | 'day' | 'hour' | 'minute'
+  inputType: 'year' | 'month' | 'day' | 'hour' | 'minute';
 }
 
 const getMaxDaysInMonth = (year: number, month: number) => {
@@ -35,11 +34,7 @@ const DateInput: React.FC<DateInputProps> = ({
     if (val === undefined) return true; // Allow empty value for clearing input
     switch (inputType) {
       case 'year':
-        return (
-          typeof val === 'string' &&
-          val >= 2020 &&
-          val <= 2040
-        ); // 최대 4자리
+        return typeof val === 'string' && val >= 2020 && val <= 2040; // 최대 4자리
       case 'month':
         return val >= 1 && val <= 12; // 1~12 사이
       case 'day':

--- a/src/components/Calendar/DatePicker.tsx
+++ b/src/components/Calendar/DatePicker.tsx
@@ -10,7 +10,11 @@ interface DatePickerProps {
   onChange?: () => void;
 }
 
-const DatePicker: React.FC<DatePickerProps> = ({ status, onDateChange, date }) => {
+const DatePicker: React.FC<DatePickerProps> = ({
+  status,
+  onDateChange,
+  date,
+}) => {
   return (
     <S.StyledPicker>
       {status === 'start' ? (
@@ -23,39 +27,68 @@ const DatePicker: React.FC<DatePickerProps> = ({ status, onDateChange, date }) =
         width="58px"
         height="28px"
         margin="5px"
-        onChange={(value) => onDateChange(0, typeof value === 'string' ? parseInt(value, 10) : value)}
+        onChange={(value) =>
+          onDateChange(
+            0,
+            typeof value === 'string' ? parseInt(value, 10) : value,
+          )
+        }
         inputType="year"
-      />년
+      />
+      년
       <DateInput
         value={date[1]}
         width="37px"
         height="28px"
         margin="5px"
-        onChange={(value) => onDateChange(1, typeof value === 'string' ? parseInt(value, 10) : value)}
+        onChange={(value) =>
+          onDateChange(
+            1,
+            typeof value === 'string' ? parseInt(value, 10) : value,
+          )
+        }
         inputType="month"
-      />월
+      />
+      월
       <DateInput
         value={date[2]}
         width="37px"
         height="28px"
         margin="5px"
-        onChange={(value) => onDateChange(2, typeof value === 'string' ? parseInt(value, 10) : value)}
+        onChange={(value) =>
+          onDateChange(
+            2,
+            typeof value === 'string' ? parseInt(value, 10) : value,
+          )
+        }
         inputType="day"
-      />일
+      />
+      일
       <DateInput
         value={date[3]}
         width="37px"
         height="28px"
         margin="5px"
-        onChange={(value) => onDateChange(3, typeof value === 'string' ? parseInt(value, 10) : value)}
+        onChange={(value) =>
+          onDateChange(
+            3,
+            typeof value === 'string' ? parseInt(value, 10) : value,
+          )
+        }
         inputType="hour"
-      />:
+      />
+      :
       <DateInput
         value={date[4]}
         width="37px"
         height="28px"
         margin="5px"
-        onChange={(value) => onDateChange(4, typeof value === 'string' ? parseInt(value, 10) : value)}
+        onChange={(value) =>
+          onDateChange(
+            4,
+            typeof value === 'string' ? parseInt(value, 10) : value,
+          )
+        }
         inputType="minute"
       />
     </S.StyledPicker>

--- a/src/components/Calendar/DatePicker.tsx
+++ b/src/components/Calendar/DatePicker.tsx
@@ -1,8 +1,7 @@
-import styled from 'styled-components';
-
 import icCalendar from '@/assets/images/ic_date.svg';
 import icWave from '@/assets/images/ic_wave.svg';
 import DateInput from '@/components/Calendar/DateInput';
+import * as S from '@/styles/calendar/DatePicker.styled';
 
 interface DatePickerProps {
   status: string;
@@ -11,25 +10,13 @@ interface DatePickerProps {
   onChange?: () => void;
 }
 
-const StyledPicker = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-  padding: 5px;
-`;
-
-const WaveImg = styled.img`
-  margin: 0px 6px;
-`;
-
 const DatePicker: React.FC<DatePickerProps> = ({ status, onDateChange, date }) => {
   return (
-    <StyledPicker>
+    <S.StyledPicker>
       {status === 'start' ? (
         <img src={icCalendar} alt="달력" />
       ) : (
-        <WaveImg src={icWave} alt="물결" />
+        <S.WaveImg src={icWave} alt="물결" />
       )}
       <DateInput
         value={date[0]}
@@ -71,7 +58,7 @@ const DatePicker: React.FC<DatePickerProps> = ({ status, onDateChange, date }) =
         onChange={(value) => onDateChange(4, typeof value === 'string' ? parseInt(value, 10) : value)}
         inputType="minute"
       />
-    </StyledPicker>
+    </S.StyledPicker>
   );
 };
 

--- a/src/components/Calendar/EventDetailTitle.tsx
+++ b/src/components/Calendar/EventDetailTitle.tsx
@@ -1,15 +1,17 @@
-import Modal from 'react-modal';
+/* eslint-disable no-console */
+/* eslint-disable no-alert */
 import axios from 'axios';
+import Modal from 'react-modal';
 
-import React, { useState, useContext } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { UserContext } from '@/service/UserContext';
-import LeftButton from '@/components/Header/LeftButton';
-import IndexButton from '@/components/Header/IndexButton';
 import EditDelModal from '@/components/EditDelModal';
+import IndexButton from '@/components/Header/IndexButton';
+import LeftButton from '@/components/Header/LeftButton';
 import UserAPI from '@/service/UserAPI';
+import { UserContext } from '@/service/UserContext';
 import * as S from '@/styles/calendar/EventDetailTitle.styled';
 import { adminModalStyles } from '@/styles/calendar/EventDetailTitle.styled';
+import React, { useContext, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 Modal.setAppElement('#root');
 
@@ -21,7 +23,13 @@ interface EventDetailTitleProps {
   isMeeting: boolean;
 }
 
-const EventDetailTitle: React.FC<EventDetailTitleProps> = ({ id, text, writer, createdAt, isMeeting }) => {
+const EventDetailTitle: React.FC<EventDetailTitleProps> = ({
+  id,
+  text,
+  writer,
+  createdAt,
+  isMeeting,
+}) => {
   const { userData } = useContext(UserContext);
   const [adminModalIsOpen, setAdminModalIsOpen] = useState(false);
   const navi = useNavigate();
@@ -52,6 +60,7 @@ const EventDetailTitle: React.FC<EventDetailTitleProps> = ({ id, text, writer, c
         navi('/calendar');
       } catch (err) {
         alert('삭제 중 오류가 발생했습니다.');
+        console.error(err);
       }
     }
   };

--- a/src/components/Calendar/EventDetailTitle.tsx
+++ b/src/components/Calendar/EventDetailTitle.tsx
@@ -1,4 +1,3 @@
-import styled from 'styled-components';
 import Modal from 'react-modal';
 import axios from 'axios';
 
@@ -7,9 +6,10 @@ import { useNavigate } from 'react-router-dom';
 import { UserContext } from '@/service/UserContext';
 import LeftButton from '@/components/Header/LeftButton';
 import IndexButton from '@/components/Header/IndexButton';
-import theme from '@/styles/theme';
 import EditDelModal from '@/components/EditDelModal';
 import UserAPI from '@/service/UserAPI';
+import * as S from '@/styles/calendar/EventDetailTitle.styled';
+import { adminModalStyles } from '@/styles/calendar/EventDetailTitle.styled';
 
 Modal.setAppElement('#root');
 
@@ -20,48 +20,6 @@ interface EventDetailTitleProps {
   createdAt: string;
   isMeeting: boolean;
 }
-
-const StyledTitle = styled.div`
-  margin: 25px 25px 20px 25px; //기본 헤더 마진
-`;
-
-const StyledHeader = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-`;
-
-const Title = styled.div`
-  font-family: ${theme.font.family.pretendard_semiBold};
-  font-size: 24px;
-  padding: 10px 0px;
-`;
-
-const Writer = styled.div`
-  font-family: ${theme.font.family.pretendard_regular};
-  font-size: 12px;
-  color: #a6a6a6;
-`;
-
-const WrittenTime = styled.div`
-  font-family: ${theme.font.family.pretendard_regular};
-  font-size: 12px;
-  color: #a6a6a6;
-`;
-
-const Detail = styled.div`
-  display: flex;
-
-  div {
-    margin-right: 10px;
-  }
-`;
-
-const adminModalStyles = {
-  overlay: {
-    backgroundColor: 'rgba(0,0,0,0.4)',
-  },
-};
 
 const EventDetailTitle: React.FC<EventDetailTitleProps> = ({ id, text, writer, createdAt, isMeeting }) => {
   const { userData } = useContext(UserContext);
@@ -103,21 +61,21 @@ const EventDetailTitle: React.FC<EventDetailTitleProps> = ({ id, text, writer, c
   }
 
   return (
-    <StyledTitle>
+    <S.StyledTitle>
       <UserAPI />
-      <StyledHeader>
+      <S.StyledHeader>
         <LeftButton />
         {userData.role === 'ADMIN' && !isMeeting ? (
           <IndexButton onClick={openAdminModal} />
         ) : null}
-      </StyledHeader>
-      <Title>{text}</Title>
-      <Detail>
-        <Writer>{writer}</Writer>
-        <WrittenTime>
+      </S.StyledHeader>
+      <S.Title>{text}</S.Title>
+      <S.Detail>
+        <S.Writer>{writer}</S.Writer>
+        <S.WrittenTime>
           {splittedDate[0].replace(/-/gi, '/')} {splittedTime}
-        </WrittenTime>
-      </Detail>
+        </S.WrittenTime>
+      </S.Detail>
 
       <Modal
         className="calendar-modal"
@@ -134,7 +92,7 @@ const EventDetailTitle: React.FC<EventDetailTitleProps> = ({ id, text, writer, c
           onClickCancel={closeAdminModal}
         />
       </Modal>
-    </StyledTitle>
+    </S.StyledTitle>
   );
 };
 

--- a/src/components/Calendar/ModalMonthContent.tsx
+++ b/src/components/Calendar/ModalMonthContent.tsx
@@ -1,8 +1,7 @@
 import { useState } from 'react';
-import styled from 'styled-components';
-import theme from '@/styles/theme';
 import TextButton from '@/components/Header/TextButton';
 import DateInput from '@/components/Calendar/DateInput';
+import * as S from '@/styles/calendar/ModalMonthContent.styled';
 
 interface ModalMonthContentProps {
   origYear: number;
@@ -12,36 +11,6 @@ interface ModalMonthContentProps {
   editMonth: (numericValue: number) => void;
   editYear: (numericValue: number) => void;
 }
-
-const StyledContent = styled.div<{ $isMonth: boolean }>`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: ${(props) => (props.$isMonth ? '275px' : '121px')};
-  height: 38px;
-  background: ${theme.color.grayScale.gray18};
-  border-radius: 14px;
-  padding: 20px;
-  margin: auto;
-  font-family: ${theme.font.family.pretendard_regular};
-  font-size: 16px;
-`;
-
-const YearButton = styled.div`
-  position: fixed;
-  width: 370px;
-  transform: translate(320px, -80px);
-`;
-
-const MonthButton = styled.div`
-  position: fixed;
-  width: 370px;
-  transform: translate(320px, -80px);
-`;
-
-const Text = styled.div`
-  margin-right: 15px;
-`;
 
 const ModalMonthContent: React.FC<ModalMonthContentProps> = ({
   origYear,
@@ -91,14 +60,14 @@ const ModalMonthContent: React.FC<ModalMonthContentProps> = ({
   if (isMonth) {
     // 달력일 경우
     return (
-      <StyledContent $isMonth={isMonth}>
-        <MonthButton>
+      <S.StyledContent $isMonth={isMonth}>
+        <S.MonthButton>
           <TextButton
             text="완료"
             color="mainColor"
             onClick={onClickTextButton}
           />
-        </MonthButton>
+        </S.MonthButton>
         <DateInput
           type="number"
           value={year}
@@ -108,7 +77,7 @@ const ModalMonthContent: React.FC<ModalMonthContentProps> = ({
           margin="10px"
           inputType="year"
         />
-        <Text>년</Text>
+        <S.Text>년</S.Text>
         <DateInput
           type="number"
           value={month}
@@ -118,16 +87,16 @@ const ModalMonthContent: React.FC<ModalMonthContentProps> = ({
           margin="10px"
           inputType="month"
         />
-        <Text>월</Text>
-      </StyledContent>
+        <S.Text>월</S.Text>
+      </S.StyledContent>
     );
   }
   // 연력일 경우
   return (
-    <StyledContent $isMonth={isMonth}>
-      <YearButton>
+    <S.StyledContent $isMonth={isMonth}>
+      <S.YearButton>
         <TextButton text="완료" color="mainColor" onClick={onClickTextButton} />
-      </YearButton>
+      </S.YearButton>
       <DateInput
         type="number"
         value={year}
@@ -137,8 +106,8 @@ const ModalMonthContent: React.FC<ModalMonthContentProps> = ({
         margin="10px"
         inputType="year"
       />
-      <Text>년</Text>
-    </StyledContent>
+      <S.Text>년</S.Text>
+    </S.StyledContent>
   );
 };
 

--- a/src/components/Calendar/ModalMonthContent.tsx
+++ b/src/components/Calendar/ModalMonthContent.tsx
@@ -1,7 +1,7 @@
-import { useState } from 'react';
-import TextButton from '@/components/Header/TextButton';
 import DateInput from '@/components/Calendar/DateInput';
+import TextButton from '@/components/Header/TextButton';
 import * as S from '@/styles/calendar/ModalMonthContent.styled';
+import { useState } from 'react';
 
 interface ModalMonthContentProps {
   origYear: number;
@@ -25,13 +25,13 @@ const ModalMonthContent: React.FC<ModalMonthContentProps> = ({
 
   const onChangeYear = (value: string | number) => {
     let numericValue: number;
-  
+
     if (typeof value === 'number') {
       numericValue = value;
     } else {
       numericValue = parseInt(value, 10);
     }
-  
+
     if (!Number.isNaN(numericValue)) {
       setYear(numericValue);
       editYear(numericValue);
@@ -44,13 +44,13 @@ const ModalMonthContent: React.FC<ModalMonthContentProps> = ({
 
   const onChangeMonth = (value: string | number) => {
     let numericValue: number;
-  
+
     if (typeof value === 'number') {
       numericValue = value;
     } else {
       numericValue = parseInt(value, 10);
     }
-  
+
     if (!Number.isNaN(numericValue)) {
       setMonth(numericValue);
       editMonth(numericValue);

--- a/src/components/Calendar/MonthCalendar.tsx
+++ b/src/components/Calendar/MonthCalendar.tsx
@@ -1,13 +1,13 @@
 /* eslint-disable no-console */
-import { useEffect, useRef, useContext, useState } from 'react';
-import FullCalendar from '@fullcalendar/react';
-import dayGridPlugin from '@fullcalendar/daygrid';
-import { format } from 'date-fns';
-import { useNavigate } from 'react-router-dom';
-import { MonthlyScheduleContext } from '@/service/MonthlyScheduleContext';
 import MonthlyShceduleAPI from '@/service/MonthlyScheduleAPI';
+import { MonthlyScheduleContext } from '@/service/MonthlyScheduleContext';
 import UserAPI from '@/service/UserAPI';
 import * as S from '@/styles/calendar/MonthCalendar.styled';
+import dayGridPlugin from '@fullcalendar/daygrid';
+import FullCalendar from '@fullcalendar/react';
+import { format } from 'date-fns';
+import { useContext, useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 interface MonthCalendarProps {
   year: number;
@@ -15,7 +15,6 @@ interface MonthCalendarProps {
   editYear: (newYear: number) => void;
   editMonth: (newMonth: number) => void;
 }
-
 
 const MonthCalendar: React.FC<MonthCalendarProps> = ({ year, month }) => {
   const calendarRef = useRef<FullCalendar | null>(null);
@@ -94,10 +93,7 @@ const MonthCalendar: React.FC<MonthCalendarProps> = ({ year, month }) => {
   return (
     <S.CalendarContainer>
       <UserAPI />
-      <MonthlyShceduleAPI
-        start={formattedStart}
-        end={formattedEnd}
-      />
+      <MonthlyShceduleAPI start={formattedStart} end={formattedEnd} />
       <FullCalendar
         ref={calendarRef}
         plugins={[dayGridPlugin]}

--- a/src/components/Calendar/MonthCalendar.tsx
+++ b/src/components/Calendar/MonthCalendar.tsx
@@ -2,13 +2,12 @@
 import { useEffect, useRef, useContext, useState } from 'react';
 import FullCalendar from '@fullcalendar/react';
 import dayGridPlugin from '@fullcalendar/daygrid';
-import styled from 'styled-components';
 import { format } from 'date-fns';
 import { useNavigate } from 'react-router-dom';
-import theme from '@/styles/theme';
 import { MonthlyScheduleContext } from '@/service/MonthlyScheduleContext';
 import MonthlyShceduleAPI from '@/service/MonthlyScheduleAPI';
 import UserAPI from '@/service/UserAPI';
+import * as S from '@/styles/calendar/MonthCalendar.styled';
 
 interface MonthCalendarProps {
   year: number;
@@ -17,117 +16,6 @@ interface MonthCalendarProps {
   editMonth: (newMonth: number) => void;
 }
 
-const CalendarContainer = styled.div`
-  width: 100%;
-  padding-bottom: 183px;
-  font-family: ${theme.font.family.pretendard_regular};
-  font-size: 16px;
-  z-index: 2;
-
-  .fc {
-    font-size: 12px;
-    border: none;
-  }
-
-  .fc-day-today {
-    background-color: transparent !important;
-  }
-
-  .fc-scrollgrid,
-  .fc-theme-standard td,
-  .fc-theme-standard th {
-    border-color: ${theme.color.grayScale.gray12};
-  }
-
-  .fc-col-header-cell 
-  {
-    background-color: ${theme.color.grayScale.gray12};
-    padding-bottom: 15px;
-    border: none;
-  }
-
-  .fc-scrollgrid,
-  .fc-theme-standard td,
-  .fc-theme-standard th {
-    border: none;
-  }
-
-  .fc-daygrid-day-number {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    height: 100%;
-    width: 100%;
-  }
-
-  .fc-day-sun a {
-    color: ${theme.color.main.negative};
-  }
-
-  .fc-day-sat a {
-    color: ${theme.color.main.pointBlue};
-  }
-
-  .fc-event,
-  .fc-event-dot {
-    padding: 3px 10px;
-    background-color: ${theme.color.grayScale.gray18}; !important;
-    border: none;
-    border-radius: 20px;
-    color: white !important;
-    cursor: pointer;
-  }
-
-  .fc-event:hover {
-    padding: 3px 10px;
-    background-color: ${theme.color.main.pointBlue}; !important;
-    border: none;
-    border-radius: 20px;
-    color: white !important;
-    cursor: pointer;
-  }
-  
-  .fc-daygrid-event.fc-daygrid-block-event:first-child {
-    height: 19px;
-    margin-left: 2px;
-    border-top-left-radius: 20px;
-    border-bottom-left-radius: 20px;
-  }
-
-  .fc-daygrid-event.fc-daygrid-block-event:last-child {
-    border-top-right-radius: 20px;
-    border-bottom-right-radius: 20px;
-  }
-
-  .fc-daygrid-event-dot {
-    display: none;
-  }
-
-  .fc-event-time {
-    display: none;
-  }
-
-  .fc-event-title {
-    padding: 0px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    font-weight: 400; //볼드가 자동으로 생겨서 강제로 굵기를 조절했음
-  }
-`;
-
-const Today = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  position: absolute;
-  top: 1px;
-  right: 7px;
-  background: ${theme.color.main.mainColor};
-  border-radius: 10px;
-  width: 38px;
-  height: 22px;
-  z-index: 0;
-`;
 
 const MonthCalendar: React.FC<MonthCalendarProps> = ({ year, month }) => {
   const calendarRef = useRef<FullCalendar | null>(null);
@@ -172,7 +60,7 @@ const MonthCalendar: React.FC<MonthCalendarProps> = ({ year, month }) => {
       format(arg.date, 'yyyy-MM-dd') === format(new Date(), 'yyyy-MM-dd');
     return (
       <div>
-        {isToday && <Today>{arg.date.getDate()}</Today>}
+        {isToday && <S.Today>{arg.date.getDate()}</S.Today>}
         <div>{arg.date.getDate()}</div>
       </div>
     );
@@ -204,7 +92,7 @@ const MonthCalendar: React.FC<MonthCalendarProps> = ({ year, month }) => {
   }, [year, month]);
 
   return (
-    <CalendarContainer>
+    <S.CalendarContainer>
       <UserAPI />
       <MonthlyShceduleAPI
         start={formattedStart}
@@ -221,7 +109,7 @@ const MonthCalendar: React.FC<MonthCalendarProps> = ({ year, month }) => {
         dayCellContent={renderDayCell}
         height="auto"
       />
-    </CalendarContainer>
+    </S.CalendarContainer>
   );
 };
 

--- a/src/components/Calendar/MonthlyEvent.tsx
+++ b/src/components/Calendar/MonthlyEvent.tsx
@@ -1,9 +1,8 @@
 /* eslint-disable no-unused-vars */
 /* eslint-disable no-console */
 import React from 'react';
-import styled from 'styled-components';
-import theme from '@/styles/theme';
 import icDot from '@/assets/images/ic_dot.svg';
+import * as S from '@/styles/calendar/MonthlyEvent.styled';
 
 interface EventComponentProps {
   title: string;
@@ -23,51 +22,12 @@ interface Event {
   isMeeting: boolean;
 }
 
-const StyledYear = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  font-family: ${theme.font.family.pretendard_regular};
-  font-size: 16px;
-`;
-
-const ContentWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  background-color: ${theme.color.grayScale.gray18};
-  padding: 10px;
-  margin-bottom: 15px;
-  width: 143px; //사이즈 수정 필요
-  border-radius: 10px;
-  font-size: 14px;
-`;
-
-const Content = styled.div`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  padding: 5px 0px;
-`;
-
-const Dot = styled.img`
-  padding-left: 8px;
-  padding-right: 10px;
-`;
-
-const MonthName = styled.div<{ $isToday: boolean }>`
-  padding-left: 10px;
-  padding-bottom: 7px;
-  color: ${(props) => (props.$isToday === true ? '#00dda8' : '#ffffff')};
-  font-size: 18px;
-  font-family: ${theme.font.family.pretendard_semiBold};
-`;
-
 const EventComponent: React.FC<EventComponentProps> = ({ title }) => {
   return (
-    <Content>
-      <Dot src={icDot} alt="dot" />
+    <S.Content>
+      <S.Dot src={icDot} alt="dot" />
       <div>{title}</div>
-    </Content>
+    </S.Content>
   );
 };
 
@@ -77,9 +37,9 @@ const MonthlyEvent: React.FC<MonthlyEventProps> = ({ thisMonth, year, events }) 
   const istoday = thisMonth === todayMonth && todayYear === year;
 
   return (
-    <StyledYear>
-      <MonthName $isToday={istoday}>{thisMonth}월</MonthName>
-      <ContentWrapper>
+    <S.StyledYear>
+      <S.MonthName $isToday={istoday}>{thisMonth}월</S.MonthName>
+      <S.ContentWrapper>
         {events.length > 0 ? (
           events.map((event) => (
             <EventComponent key={event.id} title={event.title} />
@@ -87,8 +47,8 @@ const MonthlyEvent: React.FC<MonthlyEventProps> = ({ thisMonth, year, events }) 
         ) : (
           <EventComponent title="일정이 없습니다!" />
         )}
-      </ContentWrapper>
-    </StyledYear>
+      </S.ContentWrapper>
+    </S.StyledYear>
   );
 };
 

--- a/src/components/Calendar/MonthlyEvent.tsx
+++ b/src/components/Calendar/MonthlyEvent.tsx
@@ -1,17 +1,11 @@
 /* eslint-disable no-unused-vars */
 /* eslint-disable no-console */
-import React from 'react';
 import icDot from '@/assets/images/ic_dot.svg';
 import * as S from '@/styles/calendar/MonthlyEvent.styled';
+import React from 'react';
 
 interface EventComponentProps {
   title: string;
-}
-
-interface MonthlyEventProps {
-  thisMonth: number;
-  year: string | number;
-  events: Event[];
 }
 
 interface Event {
@@ -20,6 +14,12 @@ interface Event {
   start: string;
   end: string;
   isMeeting: boolean;
+}
+
+interface MonthlyEventProps {
+  thisMonth: number;
+  year: string | number;
+  events: Event[];
 }
 
 const EventComponent: React.FC<EventComponentProps> = ({ title }) => {
@@ -31,7 +31,11 @@ const EventComponent: React.FC<EventComponentProps> = ({ title }) => {
   );
 };
 
-const MonthlyEvent: React.FC<MonthlyEventProps> = ({ thisMonth, year, events }) => {
+const MonthlyEvent: React.FC<MonthlyEventProps> = ({
+  thisMonth,
+  year,
+  events,
+}) => {
   const todayMonth = new Date().getMonth() + 1;
   const todayYear = new Date().getFullYear();
   const istoday = thisMonth === todayMonth && todayYear === year;

--- a/src/components/Calendar/ToggleButton.tsx
+++ b/src/components/Calendar/ToggleButton.tsx
@@ -1,73 +1,8 @@
 import { useState } from 'react';
-import styled from 'styled-components';
-import theme from '@/styles/theme';
-
+import * as S from '@/styles/calendar/ToggleButton.styled';
 interface ToggleButtonProps {
   onToggle: (isMonth: boolean) => void;
 }
-
-const Switch = styled.label`
-  position: relative;
-  display: inline-block;
-  width: 343px;
-  height: 32px;
-  margin-top: 15px;
-  margin-bottom: 15px;
-`;
-
-const Checkbox = styled.input`
-  opacity: 0;
-  width: 0;
-  height: 0;
-`;
-
-const Slider = styled.span<{ $isChecked: boolean }>`
-  display: flex;
-  align-items: center;
-  position: absolute;
-  cursor: pointer;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: ${theme.color.grayScale.gray18};
-  transition: 0.4s;
-  border-radius: 10px;
-
-  &:before {
-    position: absolute;
-    content: '';
-    height: 28px;
-    width: 170px;
-    left: 2px;
-    bottom: 2px;
-    background-color: ${theme.color.grayScale.gray30};
-    transition: 0.4s;
-    border-radius: 9px;
-    transform: ${(props) =>
-      props.$isChecked ? 'translateX(169px)' : 'translateX(0)'};
-  }
-`;
-
-const TextMonth = styled.span<{ $isChecked: boolean}>`
-  position: absolute;
-  left: 18%;
-  color: ${(props) => (props.$isChecked ? '#a6a6a6' : '#ffffff')};
-  //eslint 이슈로 색상코드를 작성하였음
-  font-family: ${theme.font.family.pretendard_semiBold};
-  font-size: 12px;
-  z-index: 1;
-`;
-
-const TextYear = styled.span<{ $isChecked: boolean }>`
-  position: absolute;
-  right: 22%;
-  color: ${(props) => (props.$isChecked ? '#ffffff' : '#a6a6a6')};
-  //eslint 이슈로 색상코드를 작성하였음
-  font-family: ${theme.font.family.pretendard_semiBold};
-  font-size: 12px;
-  z-index: 1;
-`;
 
 const ToggleButton: React.FC<ToggleButtonProps> = ({ onToggle }) => {
   const [isMonth, setIsMonth] = useState(false);
@@ -79,13 +14,13 @@ const ToggleButton: React.FC<ToggleButtonProps> = ({ onToggle }) => {
 
   return (
     <div>
-      <Switch>
-        <Checkbox type="checkbox" checked={isMonth} onChange={handleToggle} />
-        <Slider $isChecked={isMonth}>
-          <TextMonth $isChecked={isMonth}>Month</TextMonth>
-          <TextYear $isChecked={isMonth}>Year</TextYear>
-        </Slider>
-      </Switch>
+      <S.Switch>
+        <S.Checkbox type="checkbox" checked={isMonth} onChange={handleToggle} />
+        <S.Slider $isChecked={isMonth}>
+          <S.TextMonth $isChecked={isMonth}>Month</S.TextMonth>
+          <S.TextYear $isChecked={isMonth}>Year</S.TextYear>
+        </S.Slider>
+      </S.Switch>
     </div>
   );
 };

--- a/src/components/Calendar/ToggleButton.tsx
+++ b/src/components/Calendar/ToggleButton.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
 import * as S from '@/styles/calendar/ToggleButton.styled';
+import { useState } from 'react';
+
 interface ToggleButtonProps {
   onToggle: (isMonth: boolean) => void;
 }

--- a/src/components/Calendar/YearCalendar.tsx
+++ b/src/components/Calendar/YearCalendar.tsx
@@ -1,6 +1,6 @@
+import theme from '@/styles/theme';
 import React, { useContext } from 'react';
 import styled from 'styled-components';
-import theme from '@/styles/theme';
 
 import MonthlyEvent from '@/components/Calendar/MonthlyEvent';
 import { YearlyScheduleContext } from '@/service/YearlyScheduleContext';

--- a/src/components/Calendar/YearCalendar.tsx
+++ b/src/components/Calendar/YearCalendar.tsx
@@ -1,6 +1,5 @@
-import theme from '@/styles/theme';
+import * as S from '@/styles/calendar/YearCalendar.styled';
 import React, { useContext } from 'react';
-import styled from 'styled-components';
 
 import MonthlyEvent from '@/components/Calendar/MonthlyEvent';
 import { YearlyScheduleContext } from '@/service/YearlyScheduleContext';
@@ -9,29 +8,6 @@ interface YearCalendarProps {
   year: string;
 }
 
-const MonthlyBox = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  width: 370px;
-  padding-bottom: 183px;
-`;
-
-const FirstHalfMonth = styled.div`
-  padding-left: 15px;
-`;
-
-const SecondHalfMonth = styled.div`
-  padding-right: 15px;
-`;
-
-const Error = styled.div`
-  display: flex;
-  justify-content: center;
-  margin-top: 20px;
-  font-family: ${theme.font.family.pretendard_semiBold};
-`;
-
 const allMonth = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
 
 const YearCalendar: React.FC<YearCalendarProps> = ({ year }) => {
@@ -39,16 +15,16 @@ const YearCalendar: React.FC<YearCalendarProps> = ({ year }) => {
   const { yearScheduleData, error } = useContext(YearlyScheduleContext);
 
   if (error) {
-    return <Error>데이터를 불러오는 중 문제가 발생했습니다</Error>;
+    return <S.Error>데이터를 불러오는 중 문제가 발생했습니다</S.Error>;
   }
 
   if (!yearScheduleData) {
-    return <Error>Loading...</Error>;
+    return <S.Error>Loading...</S.Error>;
   }
 
   return (
-    <MonthlyBox>
-      <FirstHalfMonth>
+    <S.MonthlyBox>
+      <S.FirstHalfMonth>
         {allMonth
           .filter((monthItem) => monthItem >= 1 && monthItem <= 6)
           .map((monthItem) => (
@@ -59,8 +35,8 @@ const YearCalendar: React.FC<YearCalendarProps> = ({ year }) => {
               events={yearScheduleData[monthItem] || []}
             />
           ))}
-      </FirstHalfMonth>
-      <SecondHalfMonth>
+      </S.FirstHalfMonth>
+      <S.SecondHalfMonth>
         {allMonth
           .filter((monthItem) => monthItem >= 7 && monthItem <= 12)
           .map((monthItem) => (
@@ -71,8 +47,8 @@ const YearCalendar: React.FC<YearCalendarProps> = ({ year }) => {
               events={yearScheduleData[monthItem] || []}
             />
           ))}
-      </SecondHalfMonth>
-    </MonthlyBox>
+      </S.SecondHalfMonth>
+    </S.MonthlyBox>
   );
 };
 

--- a/src/components/Member/Category.tsx
+++ b/src/components/Member/Category.tsx
@@ -1,53 +1,11 @@
-import styled from 'styled-components';
 import { useState, useRef } from 'react';
 import { useDraggable } from '@/service/useDraggable';
-import theme from '../../styles/theme';
+import * as S from '@/styles/memeber/Category.styled';
 
 interface CategoryProps {
   setSelectedCardinal: (index: number) => void;
   index?: number;
 }
-
-const StyledCategory = styled.div`
-  display: flex;
-  padding-top: 20px;
-  overflow-x: auto;
-  white-space: nowrap;
-  font-family: ${theme.font.family.pretendard_regular};
-  font-size: 16px;
-`;
-
-const ScrollContainer = styled.div`
-  display: flex;
-  width: 94%;
-  overflow-x: auto;
-  cursor: grab;
-  &::-webkit-scrollbar {
-    height: 1px;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    border-radius: 4px;
-  }
-
-  &::-webkit-scrollbar-thumb:hover {
-  }
-`;
-
-const Button = styled.button<{ $isSelected: boolean }>`
-  background-color: transparent;
-  border: none;
-  height: 39px;
-  width: 62px;
-  flex-shrink: 0;
-  border: 2px solid;
-  border-width: 0 0 2px;
-  border-color: ${(props) => (props.$isSelected ? 'white' : 'transparent')};
-  color: white;
-  cursor: pointer;
-  font-size: 16px;
-  font-family: ${theme.font.family.pretendard_semiBold};
-`;
 
 const Category: React.FC<CategoryProps> = ({ setSelectedCardinal }) => {
   const [selectedCategory, setSelectedCategory] = useState(0);
@@ -62,51 +20,51 @@ const Category: React.FC<CategoryProps> = ({ setSelectedCardinal }) => {
     useDraggable(scrollerRef1);
 
   return (
-    <StyledCategory>
-      <ScrollContainer
+    <S.StyledCategory>
+      <S.ScrollContainer
         ref={scrollerRef1}
         onMouseDown={onMouseDown}
         onMouseMove={onMouseMove}
         onMouseUp={onMouseUp}
         onMouseLeave={onMouseLeave}
       >
-        <Button
+        <S.Button
           type="button"
           $isSelected={selectedCategory === 0}
           onClick={() => onClickCardinal(0)}
         >
           전체
-        </Button>
-        <Button
+        </S.Button>
+        <S.Button
           type="button"
           $isSelected={selectedCategory === 4}
           onClick={() => onClickCardinal(4)}
         >
           4기
-        </Button>
-        <Button
+        </S.Button>
+        <S.Button
           type="button"
           $isSelected={selectedCategory === 3}
           onClick={() => onClickCardinal(3)}
         >
           3기
-        </Button>
-        <Button
+        </S.Button>
+        <S.Button
           type="button"
           $isSelected={selectedCategory === 2}
           onClick={() => onClickCardinal(2)}
         >
           2기
-        </Button>
-        <Button
+        </S.Button>
+        <S.Button
           type="button"
           $isSelected={selectedCategory === 1}
           onClick={() => onClickCardinal(1)}
         >
           1기
-        </Button>
-      </ScrollContainer>
-    </StyledCategory>
+        </S.Button>
+      </S.ScrollContainer>
+    </S.StyledCategory>
   );
 };
 

--- a/src/components/Member/Category.tsx
+++ b/src/components/Member/Category.tsx
@@ -1,6 +1,6 @@
-import { useState, useRef } from 'react';
 import { useDraggable } from '@/service/useDraggable';
 import * as S from '@/styles/memeber/Category.styled';
+import { useRef, useState } from 'react';
 
 interface CategoryProps {
   setSelectedCardinal: (index: number) => void;

--- a/src/components/Member/InfoComponent.tsx
+++ b/src/components/Member/InfoComponent.tsx
@@ -1,5 +1,4 @@
-import styled from 'styled-components';
-import theme from '../../styles/theme';
+import * as S from '@/styles/memeber/InfoComponent.styled';
 
 interface InfoComponentProps {
   src: string;
@@ -8,31 +7,12 @@ interface InfoComponentProps {
   value: string | number | number[];
 }
 
-const Line = styled.div`
-  border: 1px solid;
-  width: 325px;
-  transform: scaleY(0.2);
-  margin: auto;
-`;
-
-const Info = styled.div`
-  display: flex;
-  align-items: center;
-  margin: 25px;
-`;
-
-const Text = styled.div`
-  display: flex;
-  justify-content: space-between;
-  width: 100%;
-  margin-left: 10px;
-`;
-
-const MainColor = styled.div`
-  color: ${theme.color.main.mainColor};
-`;
-
-const InfoComponent: React.FC<InfoComponentProps> = ({ src, alt, index, value }) => {
+const InfoComponent: React.FC<InfoComponentProps> = ({
+  src,
+  alt,
+  index,
+  value,
+}) => {
   let positionKo = 'none';
 
   switch (value) {
@@ -64,14 +44,14 @@ const InfoComponent: React.FC<InfoComponentProps> = ({ src, alt, index, value })
 
   return (
     <div>
-      <Info>
+      <S.Info>
         <img src={src} alt={alt} />
-        <Text>
+        <S.Text>
           <div>{index}</div>
-          <MainColor>{renderValue()}</MainColor>
-        </Text>
-      </Info>
-      <Line />
+          <S.MainColor>{renderValue()}</S.MainColor>
+        </S.Text>
+      </S.Info>
+      <S.Line />
     </div>
   );
 };

--- a/src/components/Member/MemberHeader.tsx
+++ b/src/components/Member/MemberHeader.tsx
@@ -4,6 +4,8 @@ import LeftButton from '../Header/LeftButton';
 import Title from '../Header/Title';
 import theme from '../../styles/theme';
 
+// 모든 Header를 하나의 컴포넌트로 통합할 예정이라 분리하지 않음
+
 const StyledHeader = styled.div`
   display: flex;
   align-items: center;

--- a/src/components/Member/MemberName.tsx
+++ b/src/components/Member/MemberName.tsx
@@ -1,13 +1,11 @@
-/* eslint-disable react/require-default-props */
-import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 
-import FE from '../../assets/images/ic_FE.svg';
-import BE from '../../assets/images/ic_BE.svg';
-import D from '../../assets/images/ic_DE.svg';
-import MA from '../../assets/images/ic_MA.svg';
+import FE from '@/assets/images/ic_FE.svg';
+import BE from '@/assets/images/ic_BE.svg';
+import D from '@/assets/images/ic_DE.svg';
+import MA from '@/assets/images/ic_MA.svg';
 
-import theme from '../../styles/theme';
+import * as S from '@/styles/memeber/MemberName.styled';
 
 interface MemberNameProps {
   name: string;
@@ -18,40 +16,6 @@ interface MemberNameProps {
   position: string;
   isLast?: boolean;
 }
-const MemberWrapper = styled.div`
-  padding: 20px 10px 0px 10px;
-  font-family: ${theme.font.family.pretendard_regular};
-  font-size: 16px;
-  background-color: ${theme.color.grayScale.gray18};
-
-  &:first-of-type {
-    border-top-left-radius: 20px;
-    border-top-right-radius: 20px;
-  }
-`;
-
-const MemberContent = styled.div`
-  display: flex;
-  align-items: center;
-  cursor: pointer;
-`;
-
-const Line = styled.div`
-  border: 1px solid;
-  color: ${theme.color.grayScale.gray30};
-  width: 325px;
-  margin: auto;
-  margin-top: 10px;
-  transform: scaleY(0.2);
-`;
-
-const Caption = styled.div`
-  font-size: 12px;
-`;
-
-const TextWrapper = styled.div`
-  margin-left: 10px;
-`;
 
 const MemberName: React.FC<MemberNameProps> = ({
   name,
@@ -87,16 +51,16 @@ const MemberName: React.FC<MemberNameProps> = ({
   };
 
   return (
-    <MemberWrapper>
-      <MemberContent onClick={onClickMember}>
+    <S.MemberWrapper>
+      <S.MemberContent onClick={onClickMember}>
         <img src={imgSrc} alt={alt} />
-        <TextWrapper>
+        <S.TextWrapper>
           <div>{name}</div>
-          <Caption>{cardinal[0]}기</Caption>
-        </TextWrapper>
-      </MemberContent>
-      {!isLast && <Line />}
-    </MemberWrapper>
+          <S.Caption>{cardinal[0]}기</S.Caption>
+        </S.TextWrapper>
+      </S.MemberContent>
+      {!isLast && <S.Line />}
+    </S.MemberWrapper>
   );
 };
 

--- a/src/components/Member/MemberName.tsx
+++ b/src/components/Member/MemberName.tsx
@@ -1,8 +1,8 @@
 import { useNavigate } from 'react-router-dom';
 
-import FE from '@/assets/images/ic_FE.svg';
 import BE from '@/assets/images/ic_BE.svg';
 import D from '@/assets/images/ic_DE.svg';
+import FE from '@/assets/images/ic_FE.svg';
 import MA from '@/assets/images/ic_MA.svg';
 
 import * as S from '@/styles/memeber/MemberName.styled';

--- a/src/components/MyPage/InfoInput.tsx
+++ b/src/components/MyPage/InfoInput.tsx
@@ -1,7 +1,7 @@
-import { useState, useEffect } from 'react';
-import icVisible from '@/assets/images/ic_toggleVisible.svg';
 import icInvisible from '@/assets/images/ic_toggleInvisible.svg';
+import icVisible from '@/assets/images/ic_toggleVisible.svg';
 import * as S from '@/styles/mypage/InfoInput.styled';
+import { useEffect, useState } from 'react';
 
 interface InfoInputProps {
   text?: string;

--- a/src/components/MyPage/InfoInput.tsx
+++ b/src/components/MyPage/InfoInput.tsx
@@ -1,8 +1,7 @@
 import { useState, useEffect } from 'react';
-import styled from 'styled-components';
-import theme from '@/styles/theme';
 import icVisible from '@/assets/images/ic_toggleVisible.svg';
 import icInvisible from '@/assets/images/ic_toggleInvisible.svg';
+import * as S from '@/styles/mypage/InfoInput.styled';
 
 interface InfoInputProps {
   text?: string;
@@ -15,63 +14,6 @@ interface InfoInputProps {
   edit?: boolean;
   inputType?: 'text' | 'number' | 'no-korean' | 'eng-num';
 }
-
-const StyledInfoInput = styled.div<{ $padding: string }>`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  position: relative;
-  padding-top: 16px;
-  padding-bottom: 8px;
-  padding-left: ${(props) => props.$padding || '0px'};
-  padding-right: ${(props) => props.$padding || '0px'};
-  font-family: ${theme.font.family.pretendard_regular};
-  font-size: 16px;
-`;
-
-const Input = styled.input<{ width?: string; $edit?: boolean; align?: string }>`
-  width: ${(props) => props.width || '100%'};
-  height: 45px;
-  outline: none;
-  border: none;
-  border-radius: 4px;
-  background-color: ${theme.color.grayScale.gray18};
-  color: ${(props) => (props.$edit ? theme.color.grayScale.gray30 : 'white')};
-  text-align: ${(props) => props.align || 'right'};
-  padding-left: 10px;
-  padding-right: 10px;
-  font-family: ${theme.font.family.pretendard_regular};
-  font-size: 16px;
-
-  &::placeholder {
-    font-family: ${theme.font.family.pretendard_regular};
-  }
-`;
-
-const PwInput = styled.input<{ width?: string; align?: string }>`
-  width: ${(props) => props.width || '100%'};
-  height: 45px;
-  outline: none;
-  border: none;
-  border-radius: 4px;
-  background-color: ${theme.color.grayScale.gray18};
-  color: white;
-  padding-left: 10px;
-  padding-right: 43px;
-  text-align: ${(props) => props.align || 'right'};
-  font-size: 16px;
-  font-family: ${theme.font.family.pretendard_regular};
-
-  &::placeholder {
-    font-family: ${theme.font.family.pretendard_regular};
-  }
-`;
-
-const Visible = styled.img`
-  position: absolute;
-  right: 35px;
-  cursor: pointer;
-`;
 
 const InfoInput: React.FC<InfoInputProps> = ({
   text,
@@ -131,9 +73,9 @@ const InfoInput: React.FC<InfoInputProps> = ({
 
   if (text === '비밀번호') {
     return (
-      <StyledInfoInput $padding={padding}>
+      <S.StyledInfoInput $padding={padding}>
         <div>{text}</div>
-        <PwInput
+        <S.PwInput
           placeholder={placeholder}
           value={value as string}
           onChange={onChangeValue}
@@ -142,25 +84,25 @@ const InfoInput: React.FC<InfoInputProps> = ({
           type={passwordVisible ? 'text' : 'password'}
         />
         {passwordVisible ? (
-          <Visible
+          <S.Visible
             onClick={togglePasswordVisibility}
             src={icVisible}
             alt="숨김"
           />
         ) : (
-          <Visible
+          <S.Visible
             onClick={togglePasswordVisibility}
             src={icInvisible}
             alt="보임"
           />
         )}
-      </StyledInfoInput>
+      </S.StyledInfoInput>
     );
   }
   return (
-    <StyledInfoInput $padding={padding}>
+    <S.StyledInfoInput $padding={padding}>
       <div>{text}</div>
-      <Input
+      <S.Input
         placeholder={placeholder}
         value={value as string}
         onChange={onChangeValue}
@@ -169,7 +111,7 @@ const InfoInput: React.FC<InfoInputProps> = ({
         $edit={edit}
         type={inputType === 'number' ? 'text' : inputType}
       />
-    </StyledInfoInput>
+    </S.StyledInfoInput>
   );
 };
 

--- a/src/components/MyPage/MyPageHeader.tsx
+++ b/src/components/MyPage/MyPageHeader.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/require-default-props */
 import styled from 'styled-components';
 
 import LeftButton from '@/components/Header/LeftButton';
@@ -11,6 +10,8 @@ interface MyPageHeaderProps {
   isEdit: boolean;
   onSave?: () => void;
 }
+
+// 모든 Header를 하나의 컴포넌트로 통합할 예정이라 분리하지 않음
 
 const StyledHeader = styled.div`
   display: flex;

--- a/src/styles/calendar/CalendarHeader.styled.ts
+++ b/src/styles/calendar/CalendarHeader.styled.ts
@@ -1,0 +1,58 @@
+import styled from 'styled-components';
+import theme from '@/styles/theme';
+
+export const StyledHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 25px 25px 20px 25px; //기본 헤더 마진
+`;
+
+export const TitleWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+`;
+
+export const TitleYear = styled.div`
+  font-size: 18px;
+  font-family: ${theme.font.family.pretendard_semiBold};
+  padding-right: 5px;
+`;
+
+export const TitleMonth = styled.div`
+  font-size: 18px;
+  font-family: ${theme.font.family.pretendard_semiBold};
+`;
+
+export const ImgButton = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  margin: 5px;
+  cursor: pointer;
+`;
+
+export const PlusButton = styled.img`
+  cursor: pointer;
+`;
+
+export const monthModalStyles = {
+  overlay: {
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    backdropFilter: 'blur(5px)', // 표준 CSS 속성
+    WebkitBackdropFilter: 'blur(5px)', // -webkit- 접두사를 사용한 속성
+    zIndex: 1000,
+    width: '100%',
+    height: '100%',
+    top: '10px',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'flex-start',
+    margin: '55px auto', // 블러가 시작되는 위치를 정하고
+  },
+  content: {
+    margin: '10px auto', // 모달은 블러 시작점으로부터 10px 떨어진 곳에 위치
+  },
+};

--- a/src/styles/calendar/CalendarHeader.styled.ts
+++ b/src/styles/calendar/CalendarHeader.styled.ts
@@ -1,5 +1,5 @@
-import styled from 'styled-components';
 import theme from '@/styles/theme';
+import styled from 'styled-components';
 
 export const StyledHeader = styled.div`
   display: flex;

--- a/src/styles/calendar/DateInput.styled.ts
+++ b/src/styles/calendar/DateInput.styled.ts
@@ -1,6 +1,6 @@
 /* eslint-disable import/prefer-default-export */
-import styled from 'styled-components';
 import theme from '@/styles/theme';
+import styled from 'styled-components';
 
 export const StyledInput = styled.input<{
   $height: string;

--- a/src/styles/calendar/DateInput.styled.ts
+++ b/src/styles/calendar/DateInput.styled.ts
@@ -1,0 +1,34 @@
+/* eslint-disable import/prefer-default-export */
+import styled from 'styled-components';
+import theme from '@/styles/theme';
+
+export const StyledInput = styled.input<{
+  $height: string;
+  $width: string;
+  $margin: string;
+}>`
+  height: ${(props) => props.$height || '0px'};
+  width: ${(props) => props.$width || '0px'};
+  outline: none;
+  border: none;
+  border-radius: 4px;
+  background-color: ${theme.color.grayScale.gray12};
+  color: white;
+  text-align: center;
+  margin-left: ${(props) => props.$margin || '0px'};
+  margin-right: ${(props) => props.$margin || '0px'};
+  padding: 0px;
+  font-size: 16px;
+  font-family: ${theme.font.family.pretendard_regular};
+
+  /* Custom CSS to remove arrows in number input */
+  /* Chrome, Safari, Edge, Opera */
+  &::-webkit-outer-spin-button,
+  &::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+
+  /* Firefox */
+  -moz-appearance: textfield;
+`;

--- a/src/styles/calendar/DatePicker.styled.ts
+++ b/src/styles/calendar/DatePicker.styled.ts
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+
+export const StyledPicker = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  padding: 5px;
+`;
+
+export const WaveImg = styled.img`
+  margin: 0px 6px;
+`;

--- a/src/styles/calendar/EventDetailTitle.styled.ts
+++ b/src/styles/calendar/EventDetailTitle.styled.ts
@@ -1,0 +1,44 @@
+import styled from 'styled-components';
+import theme from '@/styles/theme';
+
+export const StyledTitle = styled.div`
+  margin: 25px 25px 20px 25px; //기본 헤더 마진
+`;
+
+export const StyledHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+export const Title = styled.div`
+  font-family: ${theme.font.family.pretendard_semiBold};
+  font-size: 24px;
+  padding: 10px 0px;
+`;
+
+export const Writer = styled.div`
+  font-family: ${theme.font.family.pretendard_regular};
+  font-size: 12px;
+  color: #a6a6a6;
+`;
+
+export const WrittenTime = styled.div`
+  font-family: ${theme.font.family.pretendard_regular};
+  font-size: 12px;
+  color: #a6a6a6;
+`;
+
+export const Detail = styled.div`
+  display: flex;
+
+  div {
+    margin-right: 10px;
+  }
+`;
+
+export const adminModalStyles = {
+  overlay: {
+    backgroundColor: 'rgba(0,0,0,0.4)',
+  },
+};

--- a/src/styles/calendar/EventDetailTitle.styled.ts
+++ b/src/styles/calendar/EventDetailTitle.styled.ts
@@ -1,5 +1,5 @@
-import styled from 'styled-components';
 import theme from '@/styles/theme';
+import styled from 'styled-components';
 
 export const StyledTitle = styled.div`
   margin: 25px 25px 20px 25px; //기본 헤더 마진

--- a/src/styles/calendar/ModalMonthContent.styled.ts
+++ b/src/styles/calendar/ModalMonthContent.styled.ts
@@ -1,5 +1,5 @@
-import styled from 'styled-components';
 import theme from '@/styles/theme';
+import styled from 'styled-components';
 
 export const StyledContent = styled.div<{ $isMonth: boolean }>`
   display: flex;

--- a/src/styles/calendar/ModalMonthContent.styled.ts
+++ b/src/styles/calendar/ModalMonthContent.styled.ts
@@ -1,0 +1,32 @@
+import styled from 'styled-components';
+import theme from '@/styles/theme';
+
+export const StyledContent = styled.div<{ $isMonth: boolean }>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: ${(props) => (props.$isMonth ? '275px' : '121px')};
+  height: 38px;
+  background: ${theme.color.grayScale.gray18};
+  border-radius: 14px;
+  padding: 20px;
+  margin: auto;
+  font-family: ${theme.font.family.pretendard_regular};
+  font-size: 16px;
+`;
+
+export const YearButton = styled.div`
+  position: fixed;
+  width: 370px;
+  transform: translate(320px, -80px);
+`;
+
+export const MonthButton = styled.div`
+  position: fixed;
+  width: 370px;
+  transform: translate(320px, -80px);
+`;
+
+export const Text = styled.div`
+  margin-right: 15px;
+`;

--- a/src/styles/calendar/MonthCalendar.styled.ts
+++ b/src/styles/calendar/MonthCalendar.styled.ts
@@ -1,5 +1,5 @@
-import styled from 'styled-components';
 import theme from '@/styles/theme';
+import styled from 'styled-components';
 
 export const CalendarContainer = styled.div`
   width: 100%;

--- a/src/styles/calendar/MonthCalendar.styled.ts
+++ b/src/styles/calendar/MonthCalendar.styled.ts
@@ -1,0 +1,114 @@
+import styled from 'styled-components';
+import theme from '@/styles/theme';
+
+export const CalendarContainer = styled.div`
+  width: 100%;
+  padding-bottom: 183px;
+  font-family: ${theme.font.family.pretendard_regular};
+  font-size: 16px;
+  z-index: 2;
+
+  .fc {
+    font-size: 12px;
+    border: none;
+  }
+
+  .fc-day-today {
+    background-color: transparent !important;
+  }
+
+  .fc-scrollgrid,
+  .fc-theme-standard td,
+  .fc-theme-standard th {
+    border-color: ${theme.color.grayScale.gray12};
+  }
+
+  .fc-col-header-cell 
+  {
+    background-color: ${theme.color.grayScale.gray12};
+    padding-bottom: 15px;
+    border: none;
+  }
+
+  .fc-scrollgrid,
+  .fc-theme-standard td,
+  .fc-theme-standard th {
+    border: none;
+  }
+
+  .fc-daygrid-day-number {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
+    width: 100%;
+  }
+
+  .fc-day-sun a {
+    color: ${theme.color.main.negative};
+  }
+
+  .fc-day-sat a {
+    color: ${theme.color.main.pointBlue};
+  }
+
+  .fc-event,
+  .fc-event-dot {
+    padding: 3px 10px;
+    background-color: ${theme.color.grayScale.gray18}; !important;
+    border: none;
+    border-radius: 20px;
+    color: white !important;
+    cursor: pointer;
+  }
+
+  .fc-event:hover {
+    padding: 3px 10px;
+    background-color: ${theme.color.main.pointBlue}; !important;
+    border: none;
+    border-radius: 20px;
+    color: white !important;
+    cursor: pointer;
+  }
+  
+  .fc-daygrid-event.fc-daygrid-block-event:first-child {
+    height: 19px;
+    margin-left: 2px;
+    border-top-left-radius: 20px;
+    border-bottom-left-radius: 20px;
+  }
+
+  .fc-daygrid-event.fc-daygrid-block-event:last-child {
+    border-top-right-radius: 20px;
+    border-bottom-right-radius: 20px;
+  }
+
+  .fc-daygrid-event-dot {
+    display: none;
+  }
+
+  .fc-event-time {
+    display: none;
+  }
+
+  .fc-event-title {
+    padding: 0px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-weight: 400; //볼드가 자동으로 생겨서 강제로 굵기를 조절했음
+  }
+`;
+
+export const Today = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  top: 1px;
+  right: 7px;
+  background: ${theme.color.main.mainColor};
+  border-radius: 10px;
+  width: 38px;
+  height: 22px;
+  z-index: 0;
+`;

--- a/src/styles/calendar/MonthlyEvent.styled.ts
+++ b/src/styles/calendar/MonthlyEvent.styled.ts
@@ -1,0 +1,41 @@
+import styled from 'styled-components';
+import theme from '@/styles/theme';
+
+export const StyledYear = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  font-family: ${theme.font.family.pretendard_regular};
+  font-size: 16px;
+`;
+
+export const ContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  background-color: ${theme.color.grayScale.gray18};
+  padding: 10px;
+  margin-bottom: 15px;
+  width: 143px; //사이즈 수정 필요
+  border-radius: 10px;
+  font-size: 14px;
+`;
+
+export const Content = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 5px 0px;
+`;
+
+export const Dot = styled.img`
+  padding-left: 8px;
+  padding-right: 10px;
+`;
+
+export const MonthName = styled.div<{ $isToday: boolean }>`
+  padding-left: 10px;
+  padding-bottom: 7px;
+  color: ${(props) => (props.$isToday === true ? '#00dda8' : '#ffffff')};
+  font-size: 18px;
+  font-family: ${theme.font.family.pretendard_semiBold};
+`;

--- a/src/styles/calendar/MonthlyEvent.styled.ts
+++ b/src/styles/calendar/MonthlyEvent.styled.ts
@@ -1,5 +1,5 @@
-import styled from 'styled-components';
 import theme from '@/styles/theme';
+import styled from 'styled-components';
 
 export const StyledYear = styled.div`
   display: flex;

--- a/src/styles/calendar/ToggleButton.styled.ts
+++ b/src/styles/calendar/ToggleButton.styled.ts
@@ -1,0 +1,65 @@
+import styled from 'styled-components';
+import theme from '@/styles/theme';
+
+export const Switch = styled.label`
+  position: relative;
+  display: inline-block;
+  width: 343px;
+  height: 32px;
+  margin-top: 15px;
+  margin-bottom: 15px;
+`;
+
+export const Checkbox = styled.input`
+  opacity: 0;
+  width: 0;
+  height: 0;
+`;
+
+export const Slider = styled.span<{ $isChecked: boolean }>`
+  display: flex;
+  align-items: center;
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: ${theme.color.grayScale.gray18};
+  transition: 0.4s;
+  border-radius: 10px;
+
+  &:before {
+    position: absolute;
+    content: '';
+    height: 28px;
+    width: 170px;
+    left: 2px;
+    bottom: 2px;
+    background-color: ${theme.color.grayScale.gray30};
+    transition: 0.4s;
+    border-radius: 9px;
+    transform: ${(props) =>
+      props.$isChecked ? 'translateX(169px)' : 'translateX(0)'};
+  }
+`;
+
+export const TextMonth = styled.span<{ $isChecked: boolean }>`
+  position: absolute;
+  left: 18%;
+  color: ${(props) => (props.$isChecked ? '#a6a6a6' : '#ffffff')};
+  //eslint 이슈로 색상코드를 작성하였음
+  font-family: ${theme.font.family.pretendard_semiBold};
+  font-size: 12px;
+  z-index: 1;
+`;
+
+export const TextYear = styled.span<{ $isChecked: boolean }>`
+  position: absolute;
+  right: 22%;
+  color: ${(props) => (props.$isChecked ? '#ffffff' : '#a6a6a6')};
+  //eslint 이슈로 색상코드를 작성하였음
+  font-family: ${theme.font.family.pretendard_semiBold};
+  font-size: 12px;
+  z-index: 1;
+`;

--- a/src/styles/calendar/ToggleButton.styled.ts
+++ b/src/styles/calendar/ToggleButton.styled.ts
@@ -1,5 +1,5 @@
-import styled from 'styled-components';
 import theme from '@/styles/theme';
+import styled from 'styled-components';
 
 export const Switch = styled.label`
   position: relative;

--- a/src/styles/calendar/YearCalendar.styled.ts
+++ b/src/styles/calendar/YearCalendar.styled.ts
@@ -1,0 +1,25 @@
+import theme from '@/styles/theme';
+import styled from 'styled-components';
+
+export const MonthlyBox = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  width: 370px;
+  padding-bottom: 183px;
+`;
+
+export const FirstHalfMonth = styled.div`
+  padding-left: 15px;
+`;
+
+export const SecondHalfMonth = styled.div`
+  padding-right: 15px;
+`;
+
+export const Error = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-top: 20px;
+  font-family: ${theme.font.family.pretendard_semiBold};
+`;

--- a/src/styles/memeber/Category.styled.ts
+++ b/src/styles/memeber/Category.styled.ts
@@ -1,5 +1,5 @@
-import styled from 'styled-components';
 import theme from '@/styles/theme';
+import styled from 'styled-components';
 
 export const StyledCategory = styled.div`
   display: flex;

--- a/src/styles/memeber/Category.styled.ts
+++ b/src/styles/memeber/Category.styled.ts
@@ -1,0 +1,43 @@
+import styled from 'styled-components';
+import theme from '@/styles/theme';
+
+export const StyledCategory = styled.div`
+  display: flex;
+  padding-top: 20px;
+  overflow-x: auto;
+  white-space: nowrap;
+  font-family: ${theme.font.family.pretendard_regular};
+  font-size: 16px;
+`;
+
+export const ScrollContainer = styled.div`
+  display: flex;
+  width: 94%;
+  overflow-x: auto;
+  cursor: grab;
+  &::-webkit-scrollbar {
+    height: 1px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    border-radius: 4px;
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+  }
+`;
+
+export const Button = styled.button<{ $isSelected: boolean }>`
+  background-color: transparent;
+  border: none;
+  height: 39px;
+  width: 62px;
+  flex-shrink: 0;
+  border: 2px solid;
+  border-width: 0 0 2px;
+  border-color: ${(props) => (props.$isSelected ? 'white' : 'transparent')};
+  color: white;
+  cursor: pointer;
+  font-size: 16px;
+  font-family: ${theme.font.family.pretendard_semiBold};
+`;

--- a/src/styles/memeber/InfoComponent.styled.ts
+++ b/src/styles/memeber/InfoComponent.styled.ts
@@ -1,5 +1,5 @@
-import styled from 'styled-components';
 import theme from '@/styles/theme';
+import styled from 'styled-components';
 
 export const Line = styled.div`
   border: 1px solid;

--- a/src/styles/memeber/InfoComponent.styled.ts
+++ b/src/styles/memeber/InfoComponent.styled.ts
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+import theme from '@/styles/theme';
+
+export const Line = styled.div`
+  border: 1px solid;
+  width: 325px;
+  transform: scaleY(0.2);
+  margin: auto;
+`;
+
+export const Info = styled.div`
+  display: flex;
+  align-items: center;
+  margin: 25px;
+`;
+
+export const Text = styled.div`
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  margin-left: 10px;
+`;
+
+export const MainColor = styled.div`
+  color: ${theme.color.main.mainColor};
+`;

--- a/src/styles/memeber/MemberName.styled.ts
+++ b/src/styles/memeber/MemberName.styled.ts
@@ -1,0 +1,37 @@
+import styled from 'styled-components';
+import theme from '@/styles/theme';
+
+export const MemberWrapper = styled.div`
+  padding: 20px 10px 0px 10px;
+  font-family: ${theme.font.family.pretendard_regular};
+  font-size: 16px;
+  background-color: ${theme.color.grayScale.gray18};
+
+  &:first-of-type {
+    border-top-left-radius: 20px;
+    border-top-right-radius: 20px;
+  }
+`;
+
+export const MemberContent = styled.div`
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+`;
+
+export const Line = styled.div`
+  border: 1px solid;
+  color: ${theme.color.grayScale.gray30};
+  width: 325px;
+  margin: auto;
+  margin-top: 10px;
+  transform: scaleY(0.2);
+`;
+
+export const Caption = styled.div`
+  font-size: 12px;
+`;
+
+export const TextWrapper = styled.div`
+  margin-left: 10px;
+`;

--- a/src/styles/memeber/MemberName.styled.ts
+++ b/src/styles/memeber/MemberName.styled.ts
@@ -1,5 +1,5 @@
-import styled from 'styled-components';
 import theme from '@/styles/theme';
+import styled from 'styled-components';
 
 export const MemberWrapper = styled.div`
   padding: 20px 10px 0px 10px;

--- a/src/styles/mypage/InfoInput.styled.ts
+++ b/src/styles/mypage/InfoInput.styled.ts
@@ -1,0 +1,63 @@
+import styled from 'styled-components';
+import theme from '@/styles/theme';
+
+export const StyledInfoInput = styled.div<{ $padding: string }>`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  position: relative;
+  padding-top: 16px;
+  padding-bottom: 8px;
+  padding-left: ${(props) => props.$padding || '0px'};
+  padding-right: ${(props) => props.$padding || '0px'};
+  font-family: ${theme.font.family.pretendard_regular};
+  font-size: 16px;
+`;
+
+export const Input = styled.input<{
+  width?: string;
+  $edit?: boolean;
+  align?: string;
+}>`
+  width: ${(props) => props.width || '100%'};
+  height: 45px;
+  outline: none;
+  border: none;
+  border-radius: 4px;
+  background-color: ${theme.color.grayScale.gray18};
+  color: ${(props) => (props.$edit ? theme.color.grayScale.gray30 : 'white')};
+  text-align: ${(props) => props.align || 'right'};
+  padding-left: 10px;
+  padding-right: 10px;
+  font-family: ${theme.font.family.pretendard_regular};
+  font-size: 16px;
+
+  &::placeholder {
+    font-family: ${theme.font.family.pretendard_regular};
+  }
+`;
+
+export const PwInput = styled.input<{ width?: string; align?: string }>`
+  width: ${(props) => props.width || '100%'};
+  height: 45px;
+  outline: none;
+  border: none;
+  border-radius: 4px;
+  background-color: ${theme.color.grayScale.gray18};
+  color: white;
+  padding-left: 10px;
+  padding-right: 43px;
+  text-align: ${(props) => props.align || 'right'};
+  font-size: 16px;
+  font-family: ${theme.font.family.pretendard_regular};
+
+  &::placeholder {
+    font-family: ${theme.font.family.pretendard_regular};
+  }
+`;
+
+export const Visible = styled.img`
+  position: absolute;
+  right: 35px;
+  cursor: pointer;
+`;

--- a/src/styles/mypage/InfoInput.styled.ts
+++ b/src/styles/mypage/InfoInput.styled.ts
@@ -1,5 +1,5 @@
-import styled from 'styled-components';
 import theme from '@/styles/theme';
+import styled from 'styled-components';
 
 export const StyledInfoInput = styled.div<{ $padding: string }>`
   display: flex;


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
코드 가독성을 위하여 styled-component를 분리하였습니다
<br>

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

## 3. 관련 스크린샷을 첨부해주세요.

<br>

## 4. 완료 사항
- 캘린더, 멤버, 마이페이지에 대해 styled-component를 분리하였습니다
- Header 폴더의 경우 프로젝트 내에서 사용되는 모든 헤더를 하나로 통합할 예정 -> 통합하면서 수정하는 편이 나을 것 같아 수정하지 않았습니다!
- 각 페이지 폴더 내에 있는 헤더 컴포넌트도 위와 동일한 이유로 분리하지 않았습니다
- component 폴더내에 하위폴더 없이 존재하는 컴포넌트들은 폴더구조 어떻게 할지 회의 먼저 하고 분리합시다,,<br><img width="177" alt="스크린샷 2024-10-19 오전 1 21 26" src="https://github.com/user-attachments/assets/56fb5fd7-fcbe-4944-8923-115fd0fa9a04">

<br>

## 5. 추가 사항
import 정렬이 하나도 안 되어 있어서 제 vsc에 자동 정렬되는 설정을 추가했습니다
노션 FE 필독에 추가해두었으니 확인하고 같이 설정해두면 좋을 것 같아요!!

<br>
