### PR TITLE
#297 feat: 어드민 출석 관리 UI 구현

### DIFF
--- a/src/components/Admin/AttendDropdown.tsx
+++ b/src/components/Admin/AttendDropdown.tsx
@@ -1,0 +1,4 @@
+const AttendDropdown: React.FC = () => {
+  return <div>AttendDropdown</div>;
+};
+export default AttendDropdown;

--- a/src/components/Admin/Attendance.tsx
+++ b/src/components/Admin/Attendance.tsx
@@ -1,0 +1,94 @@
+import { useState } from 'react';
+import styled from 'styled-components';
+
+import theme from '@/styles/theme';
+import DropDown from '@/assets/images/ic_admin_cardinal.svg';
+
+interface AttendanceItem {
+  id: number;
+  title: string;
+  content: string;
+  start: string;
+}
+
+const AttendanceTable = styled.div`
+  width: 815px;
+  height: 72px;
+  background-color: #f2f9f8;
+  border-radius: 10px 10px 0px 0px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 15px;
+  border-bottom: 1px solid #dedede;
+`;
+
+const Wrapper = styled.div`
+  width: 100%;
+  padding: 25px 25px;
+  display: flex;
+  justify-content: space-between;
+`;
+
+const DateInfoWrapper = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const DateText = styled.span`
+  font-family: ${theme.font.regular};
+  font-size: 20px;
+  color: black;
+  margin-right: 15px;
+`;
+
+const ContentText = styled.span`
+  font-family: ${theme.font.regular};
+  font-size: 20px;
+  color: black;
+`;
+
+const Attendance: React.FC = () => {
+  const [data, setData] = useState<AttendanceItem[]>([
+    {
+      id: 1,
+      title: '정기모임',
+      content: '1주차',
+      start: '2024-08-01',
+    },
+    {
+      id: 2,
+      title: '정기모임',
+      content: '2주차',
+      start: '2024-08-02',
+    },
+    {
+      id: 3,
+      title: '정기모임',
+      content: '3주차',
+      start: '2024-08-03',
+    },
+  ]);
+
+  return (
+    <>
+      {data.map((item) => (
+        <AttendanceTable key={item.id}>
+          <Wrapper>
+            <div>
+              <DateInfoWrapper>
+                <DateText>{item.start}</DateText>
+                <ContentText>
+                  {item.content} {item.title}
+                </ContentText>
+              </DateInfoWrapper>
+            </div>
+            <img src={DropDown} alt="dropdown" />
+          </Wrapper>
+        </AttendanceTable>
+      ))}
+    </>
+  );
+};
+
+export default Attendance;

--- a/src/components/Admin/Cardinal.tsx
+++ b/src/components/Admin/Cardinal.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import styled from 'styled-components';
+import CardinalSVG from '@/assets/images/ic_admin_cardinal.svg';
+
+interface CardinalProps {
+  selectedCardinal?: string;
+  setSelectedCardinal?: (cardinal: string) => void;
+}
+
+const CardinalWrapper = styled.div`
+  width: 166px;
+  height: 80px;
+  background-color: #ffffff;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  border-radius: 5px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  margin-bottom: 30px;
+`;
+
+const CardinalButton = styled.div`
+  width: 118px;
+  height: 48px;
+  border: 1px solid #dedede;
+  background-color: #ffffff;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+  cursor: pointer;
+  border-radius: 5px;
+`;
+const DropdownMenu = styled.div``;
+const DropdownItem = styled.div``;
+
+const CardinalDropdown: React.FC<CardinalProps> = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedCardinal, setSelectedCardinal] = useState('기수');
+
+  const toggleDropdown = () => setIsOpen(!isOpen);
+  const selectCardinal = (value: string) => {
+    setSelectedCardinal(value);
+    setIsOpen(false);
+  };
+  return (
+    <CardinalWrapper>
+      <CardinalButton onClick={toggleDropdown}>
+        <div>{selectedCardinal}</div>
+        <img src={CardinalSVG} alt="cardinal" />
+      </CardinalButton>
+      {isOpen && (
+        <DropdownMenu>
+          {['4기', '3기', '2기', '1기'].map((item) => (
+            <DropdownItem key={item} onClick={() => selectCardinal(item)}>
+              {item}
+            </DropdownItem>
+          ))}
+        </DropdownMenu>
+      )}
+    </CardinalWrapper>
+  );
+};
+
+export default CardinalDropdown;

--- a/src/components/Admin/NavMenu.tsx
+++ b/src/components/Admin/NavMenu.tsx
@@ -1,4 +1,51 @@
-const NavMenu: React.FC = () => {
-  return <div>navmenu</div>;
+import styled from 'styled-components';
+
+const Container = styled.div`
+  display: flex;
+  width: 100vw;
+  height: 100vh;
+  align-items: flex-start;
+  color: black;
+`;
+
+const Sidebar = styled.div`
+  width: 248px;
+  height: 100%;
+  background-color: #ffffff;
+  border: 1px solid #f2f2f2;
+`;
+
+const ContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  height: 100%;
+`;
+
+const Topbar = styled.div`
+  height: 78px;
+  width: 100%;
+  background-color: #ffffff;
+  border: 1px solid #f2f2f2;
+`;
+
+const MainContent = styled.div`
+  flex: 1;
+  background-color: #f2f9f8;
+  border: 1px solid #f2f2f2;
+`;
+
+const NavMenu: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  return (
+    <Container>
+      <Sidebar>
+        <h1>Weeth admin</h1>
+      </Sidebar>
+      <ContentWrapper>
+        <Topbar>로그인</Topbar>
+        <MainContent>{children}</MainContent>
+      </ContentWrapper>
+    </Container>
+  );
 };
 export default NavMenu;

--- a/src/pages/admin/AdminAttendance.tsx
+++ b/src/pages/admin/AdminAttendance.tsx
@@ -1,4 +1,34 @@
+import NavMenu from '@/components/Admin/NavMenu';
+import Cardinal from '@/components/Admin/Cardinal';
+import Attendance from '@/components/Admin/Attendance';
+
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  padding: 40px 40px;
+`;
+
+const AttendanceWrapper = styled.div`
+  width: 887px;
+  height: 600px;
+  background-color: #ffffff;
+  border-radius: 5px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
 const AdminAttendance: React.FC = () => {
-  return <div>출석</div>;
+  return (
+    <NavMenu>
+      <Wrapper>
+        <Cardinal />
+        <AttendanceWrapper>
+          <Attendance />
+        </AttendanceWrapper>
+      </Wrapper>
+    </NavMenu>
+  );
 };
 export default AdminAttendance;


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
어드민 출석 관리 UI 구현
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
없습니다. 
<br>

## 3. 관련 스크린샷을 첨부해주세요.
<img width="1709" alt="image" src="https://github.com/user-attachments/assets/76e691fa-56c6-4aa3-9890-04711a6de7b5" />
<br>

## 4. 완료 사항
- 전반적인 UI 구현 완료 (기수는 추후 수정, 출석 dropdown -> 새이슈로 만들 예정)
<br>

## 5. 추가 사항
원래 위드 페이지 색상이 전체 검정색으로 구현되어있는데, 어드민 페이지는 흰색으로 구현을 해야해서 현재 일단은 100vw, 100vh로 설정해두었습니다. 
현재 어드민 출석 관리 UI 구현 중인데 공통 부분에서 충돌날것 같아서 먼저 pr 올리고 출석 dropdown 부분과 기수는 새로운 이슈파서 다시 수정할 예정입니다.
<br>
