### PR TITLE
#281 feat: 어드민 체크 분리

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -63,6 +63,7 @@ const App = () => {
         <Route path="/board/:postId" element={<BoardPostDetail />} />
         <Route path="/:type/post" element={<BoardPost />} />
 
+        <Route path="/admin" element={<AdminAttendance />} />
         <Route path="/admin/attendance" element={<AdminAttendance />} />
         <Route path="/admin/member" element={<AdminMember />} />
         <Route path="/admin/dues" element={<AdminDues />} />

--- a/src/api/useGetDuesInfo.tsx
+++ b/src/api/useGetDuesInfo.tsx
@@ -39,6 +39,8 @@ export const useGetDuesInfo = (paramsCardinal: number) => {
   const [DuesError, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (paramsCardinal === 0) return;
+
     const fetchDuesInfo = async () => {
       try {
         const response = await getDuesInfo(paramsCardinal);

--- a/src/api/useGetGlobaluserInfo.tsx
+++ b/src/api/useGetGlobaluserInfo.tsx
@@ -25,10 +25,14 @@ const getUserInfo = async () => {
 export const useGetUserInfo = () => {
   const [globalInfo, setGlobalInfo] = useState<UserInfo | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+
   const [isAdmin, setIsAdmin] = useState<boolean>(false);
 
   useEffect(() => {
     const fetchUserInfo = async () => {
+      setLoading(true);
+
       try {
         const response = await getUserInfo();
         setGlobalInfo(response.data.data);
@@ -36,13 +40,15 @@ export const useGetUserInfo = () => {
         setError(null);
       } catch (err: any) {
         setError(err.response?.data?.message);
+      } finally {
+        setLoading(false);
       }
     };
 
     fetchUserInfo();
   }, []);
 
-  return { globalInfo, isAdmin, error };
+  return { globalInfo, isAdmin, loading, error };
 };
 
 export default useGetUserInfo;

--- a/src/api/useGetGlobaluserInfo.tsx
+++ b/src/api/useGetGlobaluserInfo.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+
+const BASE_URL = import.meta.env.VITE_API_URL;
+
+interface UserInfo {
+  id: number;
+  name: string;
+  cardinals: number[];
+  role: 'USER' | 'ADMIN';
+}
+
+const getUserInfo = async () => {
+  const accessToken = localStorage.getItem('accessToken');
+  const refreshToken = localStorage.getItem('refreshToken');
+
+  return axios.get(`${BASE_URL}/api/v1/users/info`, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Authorization_refresh: `Bearer ${refreshToken}`,
+    },
+  });
+};
+
+export const useGetUserInfo = () => {
+  const [globalInfo, setGlobalInfo] = useState<UserInfo | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isAdmin, setIsAdmin] = useState<boolean>(false);
+
+  useEffect(() => {
+    const fetchUserInfo = async () => {
+      try {
+        const response = await getUserInfo();
+        setGlobalInfo(response.data.data);
+        setIsAdmin(response.data.data.role === 'ADMIN');
+        setError(null);
+      } catch (err: any) {
+        setError(err.response?.data?.message);
+      }
+    };
+
+    fetchUserInfo();
+  }, []);
+
+  return { globalInfo, isAdmin, error };
+};
+
+export default useGetUserInfo;

--- a/src/components/Dues/DuesTitle.tsx
+++ b/src/components/Dues/DuesTitle.tsx
@@ -1,5 +1,5 @@
 import useGetDuesInfo from '@/api/useGetDuesInfo';
-import useGetUserInfo from '@/api/useGetUserInfo';
+import useGetGlobaluserInfo from '@/api/useGetGlobaluserInfo';
 import receipt from '@/assets/images/ic_receipt.svg';
 import formatDateTime from '@/hooks/formatDateTime';
 import theme from '@/styles/theme';
@@ -72,8 +72,9 @@ const DuesTitle: React.FC = () => {
     }
   }
 
-  const { userInfo } = useGetUserInfo();
-  const cardinal = userInfo?.cardinals?.[userInfo.cardinals.length - 1] ?? 0;
+  const { globalInfo } = useGetGlobaluserInfo();
+  const cardinal =
+    globalInfo?.cardinals?.[globalInfo.cardinals.length - 1] ?? 0;
   const { duesInfo } = useGetDuesInfo(cardinal);
 
   const formattedTime = duesInfo ? formatDateTime(duesInfo.time) : 'N/A';

--- a/src/components/Event/EventEditor.tsx
+++ b/src/components/Event/EventEditor.tsx
@@ -12,7 +12,6 @@ import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import useGetEventInfo from '@/api/getEventInfo';
 import replaceNewLines from '@/hooks/newLine';
-import useGetUserInfo from '@/api/useGetUserInfo';
 import ISOtoArray from '@/hooks/ISOtoArray';
 import toTwoDigits from '@/hooks/toTwoDigits';
 import CardinalDropdown from '@/components/common/CardinalDropdown';
@@ -21,6 +20,7 @@ import Button from '@/components/Button/Button';
 import ToggleButton from '@/components/common/ToggleButton';
 import EventInput, { EventInputBlock } from '@/components/Event/EventInput';
 import CardinalLabel from '@/components/Event/CardinalLabel';
+import useGetGlobaluserInfo from '@/api/useGetGlobaluserInfo';
 
 function checkEmpty(
   field: string | number | undefined,
@@ -39,7 +39,7 @@ const EventEditor = () => {
 
   const { id } = useParams();
   const { data: eventDetailData, error } = useGetEventInfo('events', id);
-  const { userInfo } = useGetUserInfo();
+  const { isAdmin } = useGetGlobaluserInfo();
   const isEditMode = Boolean(id);
   const navigate = useNavigate();
 
@@ -131,7 +131,7 @@ const EventEditor = () => {
     }
   };
 
-  if (userInfo && userInfo.role !== 'ADMIN') {
+  if (!isAdmin) {
     return <S.Error>일정 생성 및 수정은 운영진만 가능합니다</S.Error>;
   }
 

--- a/src/components/Event/EventEditor.tsx
+++ b/src/components/Event/EventEditor.tsx
@@ -20,7 +20,6 @@ import Button from '@/components/Button/Button';
 import ToggleButton from '@/components/common/ToggleButton';
 import EventInput, { EventInputBlock } from '@/components/Event/EventInput';
 import CardinalLabel from '@/components/Event/CardinalLabel';
-import useGetGlobaluserInfo from '@/api/useGetGlobaluserInfo';
 
 function checkEmpty(
   field: string | number | undefined,
@@ -39,7 +38,6 @@ const EventEditor = () => {
 
   const { id } = useParams();
   const { data: eventDetailData, error } = useGetEventInfo('events', id);
-  const { isAdmin } = useGetGlobaluserInfo();
   const isEditMode = Boolean(id);
   const navigate = useNavigate();
 
@@ -130,10 +128,6 @@ const EventEditor = () => {
       }
     }
   };
-
-  if (!isAdmin) {
-    return <S.Error>일정 생성 및 수정은 운영진만 가능합니다</S.Error>;
-  }
 
   if (error) return <S.Error>{error}</S.Error>;
 

--- a/src/components/Receipt/ReceiptMain.tsx
+++ b/src/components/Receipt/ReceiptMain.tsx
@@ -3,7 +3,7 @@ import ReactModal from 'react-modal';
 import ReceiptInfo from '@/components/Receipt/ReceiptInfo';
 import * as S from '@/styles/receipt/ReceiptMain.styled';
 import useGetDuesInfo from '@/api/useGetDuesInfo';
-import useGetUserInfo from '@/api/useGetUserInfo';
+import useGetGlobaluserInfo from '@/api/useGetGlobaluserInfo';
 
 interface ReceiptProps {
   id: number;
@@ -18,8 +18,9 @@ interface GroupedByMonth {
 }
 
 const ReceiptMain: React.FC = () => {
-  const { userInfo } = useGetUserInfo();
-  const cardinal = userInfo?.cardinals?.[userInfo.cardinals.length - 1] ?? 0;
+  const { globalInfo } = useGetGlobaluserInfo();
+  const cardinal =
+    globalInfo?.cardinals?.[globalInfo.cardinals.length - 1] ?? 0;
   const { duesInfo } = useGetDuesInfo(cardinal);
 
   const [modalIsOpen, setModalIsOpen] = useState<boolean>(false);

--- a/src/components/common/AdminOnly.tsx
+++ b/src/components/common/AdminOnly.tsx
@@ -1,9 +1,49 @@
 import useGetGlobaluserInfo from '@/api/useGetGlobaluserInfo';
+import Button from '@/components/Button/Button';
+import theme from '@/styles/theme';
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
 
-const AdminOnly = () => {
+const Container = styled.div<{ isAdminPage?: boolean }>`
+  z-index: 100;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  gap: 30px;
+  width: 100vw;
+  height: 100vh;
+  font-family: ${theme.font.semiBold};
+
+  background-color: ${(props) =>
+    props.isAdminPage ? '#fff' : theme.color.gray[18]};
+  color: ${(props) => (props.isAdminPage ? '#000' : '#fff')};
+`;
+
+const AdminOnly = ({ isAdminPage }: { isAdminPage?: boolean }) => {
   const { isAdmin } = useGetGlobaluserInfo();
+  const navigate = useNavigate();
 
-  return !isAdmin && <div>운영진만 접근 가능</div>;
+  return (
+    !isAdmin && (
+      <Container isAdminPage={isAdminPage}>
+        <div>운영진만 접근 가능합니다.</div>
+        <Button
+          onClick={() => {
+            navigate('/');
+          }}
+          color={isAdminPage === true ? theme.color.main : theme.color.gray[30]}
+        >
+          서비스로 돌아가기
+        </Button>
+      </Container>
+    )
+  );
 };
 
 export default AdminOnly;

--- a/src/components/common/AdminOnly.tsx
+++ b/src/components/common/AdminOnly.tsx
@@ -1,0 +1,9 @@
+import useGetGlobaluserInfo from '@/api/useGetGlobaluserInfo';
+
+const AdminOnly = () => {
+  const { isAdmin } = useGetGlobaluserInfo();
+
+  return !isAdmin && <div>운영진만 접근 가능</div>;
+};
+
+export default AdminOnly;

--- a/src/components/common/AdminOnly.tsx
+++ b/src/components/common/AdminOnly.tsx
@@ -26,8 +26,11 @@ const Container = styled.div<{ isAdminPage?: boolean }>`
 `;
 
 const AdminOnly = ({ isAdminPage }: { isAdminPage?: boolean }) => {
-  const { isAdmin } = useGetGlobaluserInfo();
+  const { isAdmin, loading } = useGetGlobaluserInfo();
   const navigate = useNavigate();
+
+  // TODO: 로딩 컴포넌트 추가
+  if (loading) return <Container />;
 
   return (
     !isAdmin && (

--- a/src/components/home/HomeMain.tsx
+++ b/src/components/home/HomeMain.tsx
@@ -7,17 +7,17 @@ import calendar from '@/assets/images/ic_home_calendar.svg';
 import attend from '@/assets/images/ic_home_attend.svg';
 import board from '@/assets/images/ic_home_board.svg';
 import * as S from '@/styles/home/HomeMain.styled';
-import useGetUserInfo from '@/api/useGetUserInfo';
+import useGetGlobaluserInfo from '@/api/useGetGlobaluserInfo';
 
 const HomeMain: React.FC = () => {
   const navi = useNavigate();
-  const { userInfo } = useGetUserInfo();
+  const { globalInfo } = useGetGlobaluserInfo();
 
-  const userName = userInfo?.name || 'Loading';
+  const userName = globalInfo?.name || 'Loading';
   const cardinal =
-    Array.isArray(userInfo?.cardinals) && userInfo?.cardinals.length >= 2
-      ? userInfo.cardinals[userInfo.cardinals.length - 1]
-      : userInfo?.cardinals?.[0] || 'Loading';
+    Array.isArray(globalInfo?.cardinals) && globalInfo?.cardinals.length >= 2
+      ? globalInfo.cardinals[globalInfo.cardinals.length - 1]
+      : globalInfo?.cardinals?.[0] || 'Loading';
 
   return (
     <S.StyledHomeMain>

--- a/src/hooks/useGetUserName.tsx
+++ b/src/hooks/useGetUserName.tsx
@@ -1,13 +1,13 @@
-import useGetUserInfo from '@/api/useGetUserInfo';
+import useGetGlobaluserInfo from '@/api/useGetGlobaluserInfo';
 
 const useGetUserName = () => {
-  const { userInfo } = useGetUserInfo();
+  const { globalInfo } = useGetGlobaluserInfo();
 
   let name: string;
-  if (!userInfo) {
+  if (!globalInfo) {
     name = 'loading';
   } else {
-    name = userInfo.name;
+    name = globalInfo.name;
   }
 
   return name;

--- a/src/pages/Dues.tsx
+++ b/src/pages/Dues.tsx
@@ -6,18 +6,21 @@ import DuesTitle from '@/components/Dues/DuesTitle';
 import Header from '@/components/Header/Header';
 import useCustomBack from '@/hooks/useCustomBack';
 import * as S from '@/styles/dues/Dues.styled';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 const Dues: React.FC = () => {
   useCustomBack('/home');
 
   const { globalInfo } = useGetGlobaluserInfo();
 
-  const cardinal =
-    globalInfo?.cardinals?.[globalInfo.cardinals.length - 1] ?? 0;
+  const [selected, setSelectedDues] = useState<string | null>(null);
+  const [cardinal, setCardinal] = useState(0);
+
   const { duesInfo } = useGetDuesInfo(cardinal);
 
-  const [selected, setSelectedDues] = useState<string | null>(null);
+  useEffect(() => {
+    setCardinal(globalInfo?.cardinals?.[globalInfo.cardinals.length - 1] ?? 0);
+  }, [globalInfo]);
 
   const filteredDues =
     selected === null

--- a/src/pages/Dues.tsx
+++ b/src/pages/Dues.tsx
@@ -1,5 +1,5 @@
 import useGetDuesInfo from '@/api/useGetDuesInfo';
-import useGetUserInfo from '@/api/useGetUserInfo';
+import useGetGlobaluserInfo from '@/api/useGetGlobaluserInfo';
 import DueCategory from '@/components/Dues/DueCategory';
 import DuesInfo from '@/components/Dues/DuesInfo';
 import DuesTitle from '@/components/Dues/DuesTitle';
@@ -11,9 +11,10 @@ import { useState } from 'react';
 const Dues: React.FC = () => {
   useCustomBack('/home');
 
-  const { userInfo } = useGetUserInfo();
+  const { globalInfo } = useGetGlobaluserInfo();
 
-  const cardinal = userInfo?.cardinals?.[userInfo.cardinals.length - 1] ?? 0;
+  const cardinal =
+    globalInfo?.cardinals?.[globalInfo.cardinals.length - 1] ?? 0;
   const { duesInfo } = useGetDuesInfo(cardinal);
 
   const [selected, setSelectedDues] = useState<string | null>(null);

--- a/src/pages/EventDetail.tsx
+++ b/src/pages/EventDetail.tsx
@@ -4,7 +4,7 @@ import EventTitle from '@/components/Event/EventTitle';
 import EventContent from '@/components/Event/EventContent';
 import useCustomBack from '@/hooks/useCustomBack';
 import { useParams } from 'react-router-dom';
-import useGetUserInfo from '@/api/useGetUserInfo';
+import useGetGlobaluserInfo from '@/api/useGetGlobaluserInfo';
 
 export interface EventDetailData {
   id: number;
@@ -24,20 +24,16 @@ const EventDetail = () => {
   useCustomBack('/calendar');
 
   const { id, type } = useParams();
-  // TODO: 어드민 로직 수정
-  const { userInfo } = useGetUserInfo();
+  const { isAdmin } = useGetGlobaluserInfo();
   const { data: eventDetailData, error } = useGetEventInfo(type, id);
 
   if (error || !eventDetailData) return <S.Error>{error}</S.Error>;
 
   return (
     <S.EventDetailWrapper>
-      <EventTitle data={eventDetailData} isAdmin={userInfo?.role === 'ADMIN'} />
+      <EventTitle data={eventDetailData} isAdmin={isAdmin} />
       <S.Line />
-      <EventContent
-        data={eventDetailData}
-        isAdmin={userInfo?.role === 'ADMIN'}
-      />
+      <EventContent data={eventDetailData} isAdmin={isAdmin} />
     </S.EventDetailWrapper>
   );
 };

--- a/src/pages/EventPost.tsx
+++ b/src/pages/EventPost.tsx
@@ -1,10 +1,16 @@
+import AdminOnly from '@/components/common/AdminOnly';
 import EventEditor from '@/components/Event/EventEditor';
 import useCustomBack from '@/hooks/useCustomBack';
 
 const EventPost = () => {
   useCustomBack('/calendar');
 
-  return <EventEditor />;
+  return (
+    <>
+      <AdminOnly />
+      <EventEditor />
+    </>
+  );
 };
 
 export default EventPost;

--- a/src/pages/admin/AdminAttendance.tsx
+++ b/src/pages/admin/AdminAttendance.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { PageWrapper, ContentWrapper } from '@/styles/admin/AdminLayout.styled';
 import { useState } from 'react';
 import TotalCardinal from '@/components/Admin/CardinalWrapper';
+import AdminOnly from '@/components/common/AdminOnly';
 
 const AttendanceWrapper = styled.div`
   width: 100%;
@@ -35,6 +36,7 @@ const AdminAttendance: React.FC = () => {
 
   return (
     <PageWrapper>
+      <AdminOnly isAdminPage />
       <NavMenu />
       <ContentWrapper>
         <TopBar

--- a/src/pages/admin/AdminDues.tsx
+++ b/src/pages/admin/AdminDues.tsx
@@ -8,6 +8,7 @@ import DuesRegisterAdd from '@/components/Admin/DuesRegisterAdd';
 import { useState } from 'react';
 import DuesRegister from '@/components/Admin/DuesRegister';
 import TotalCardinal from '@/components/Admin/CardinalWrapper';
+import AdminOnly from '@/components/common/AdminOnly';
 
 const ContentWrapper = styled.div`
   display: flex;
@@ -58,6 +59,7 @@ const AdminDues: React.FC = () => {
 
   return (
     <PageWrapper>
+      <AdminOnly isAdminPage />
       <NavMenu />
       <ContentWrapper>
         <TopBar

--- a/src/pages/admin/AdminMember.tsx
+++ b/src/pages/admin/AdminMember.tsx
@@ -8,6 +8,7 @@ import {
   MemberProvider,
   useMemberContext,
 } from '@/components/Admin/context/MemberContext';
+import AdminOnly from '@/components/common/AdminOnly';
 import {
   PageWrapper,
   ContentWrapper,
@@ -44,6 +45,7 @@ const DynamicTopBar: React.FC = () => {
 const AdminMember: React.FC = () => {
   return (
     <MemberProvider>
+      <AdminOnly isAdminPage />
       <PageWrapper>
         <NavMenu />
         <ContentWrapper>

--- a/src/pages/admin/AdminPenalty.tsx
+++ b/src/pages/admin/AdminPenalty.tsx
@@ -3,6 +3,7 @@ import { MemberProvider } from '@/components/Admin/context/MemberContext';
 import NavMenu from '@/components/Admin/NavMenu';
 import PenaltyListTable from '@/components/Admin/PenaltyListTable';
 import TopBar from '@/components/Admin/TopBar';
+import AdminOnly from '@/components/common/AdminOnly';
 import {
   Container,
   PageWrapper,
@@ -15,6 +16,7 @@ const AdminPenalty: React.FC = () => {
 
   return (
     <MemberProvider>
+      <AdminOnly isAdminPage />
       <PageWrapper>
         <NavMenu />
         <ContentWrapper>


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
#281 을 구현했습니다
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
api 인스턴스를 적용 못 했는데 ... 어차피 추가로 수정작업 해야하는 api들이 있어서 한번에 하도록 하겠습니다! 그 외 부분만 봐주세요,,

<br>

## 3. 관련 스크린샷을 첨부해주세요.
![image](https://github.com/user-attachments/assets/006004bf-bc55-447e-8304-f77ecdb42c27)
![image](https://github.com/user-attachments/assets/7a274afe-72b1-4b2e-ae0e-eb67f9207d52)

<br>

## 4. 완료 사항
### 전역 내 정보 조회 API 연결

마이페이지가 아닌 곳에서 내 정보를 조회해야할 때는 아래 코드를 사용해주시면 됩니다!
```
  const { globalInfo } = useGetGlobaluserInfo();
```

그리고 `useGetGlobaluserInfo()`의 return 값으로 `isAdmin`도 있으니, 어드민인지 확인이 필요한 경우에는 이렇게 바로 사용 가능합니다!

```
  const { isAdmin } = useGetGlobaluserInfo();
```

기존에 `userInfo`로 사용되고 있던 부분을 `globalInfo`로 수정하였으니, 확인 부탁드립니다.
이렇게 수정하면서 globalInfo를 받아온 후에 회비 조회 요청을 보낼 수 있도록 기수가 default값(0)이면 api 요청을 보내지 않도록 설정했습니다.

### 어드민이 아닌 경우 접근을 막는 컴포넌트 구현

이게 원래는 라우팅단계에서 막으려고 했으나,,, 안되는 이유를 찾지 못해 우선은 컴포넌트를 렌더링하는 방식으로 구현했습니다. 추후 리팩토링을 고려하고 있습니다

디자인은 임의로 설정해둔 것이며, 수정될 수 있습니다

어드민이 아닐 경우 접근을 제한해야하는 페이지에서 `<AdminOnly />` 컴포넌트를 추가해주면 됩니다! 모든 로직은 해당 컴포넌트 내에 있어서 따로 추가할 내용은 없습니다🤩

다만, 디자인 통일성을 위해 조건을 설정해두었습니다.
서비스 단에서 접근을 막아야할 경우에는 props 값을 전달하지 않아도 됩니다.
어드민 페이지에서 접근을 막아야할 경우에는 `isAdminPage`값을 props로 전달해줘야합니다.

<br>

## 5. 추가 사항

<br>
