### PR TITLE
#381 fix: 멤버 qa 수정

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -40,7 +40,7 @@ import { CustomToastContainer } from '@/components/common/ToastMessage';
 const App = () => {
   return (
     <ThemeProvider theme={theme}>
-      <CustomToastContainer />
+      <CustomToastContainer limit={1} />
       <ScrollToTop />
       <Routes>
         <Route path="/" element={<Landing />} />

--- a/src/api/getEventInfo.tsx
+++ b/src/api/getEventInfo.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from 'react';
-import { toastError } from '@/components/common/ToastMessage';
 import api from './api';
 
 export const getEventInfo = async (
@@ -27,7 +26,6 @@ export const useGetEventInfo = (type?: string, id?: string) => {
           }
         }
       } catch (err: any) {
-        toastError('데이터를 불러오지 못했습니다.');
         setError(err.message || 'An error occurred');
       } finally {
         setLoading(false);

--- a/src/api/useGetAllUsers.tsx
+++ b/src/api/useGetAllUsers.tsx
@@ -1,4 +1,3 @@
-import { toastError } from '@/components/common/ToastMessage';
 import axios from 'axios';
 import { useEffect } from 'react';
 
@@ -46,7 +45,6 @@ const useGetAllUsers = (
       setUsers((prevUsers) => [...prevUsers, ...data.content]);
       setHasMore(!data.last);
     } catch (error) {
-      toastError('데이터를 불러오지 못했습니다.');
       console.error('Error fetching users:', error);
     } finally {
       setIsLoading(false);

--- a/src/components/Event/EventTitle.tsx
+++ b/src/components/Event/EventTitle.tsx
@@ -64,11 +64,7 @@ const EventTitle = ({
         </S.SpaceBetween>
 
         {isMenuModalOpen && (
-          <MenuModal
-            onClose={() => setIsMenuModalOpen(false)}
-            top={-65}
-            right={630}
-          >
+          <MenuModal onClose={() => setIsMenuModalOpen(false)}>
             <S.TextButton onClick={() => navigate(`/${type}/${id}/edit`)}>
               수정
             </S.TextButton>

--- a/src/components/Member/MemberList.tsx
+++ b/src/components/Member/MemberList.tsx
@@ -106,7 +106,7 @@ const MemberList = ({
           style={{ height: '20px', backgroundColor: 'transparent' }}
         />
       )}
-      {!hasMore && <Error>마지막 멤버입니다.</Error>}
+      {!hasMore && !isSearch && <Error>마지막 멤버입니다.</Error>}
     </List>
   );
 };

--- a/src/components/Member/MemberList.tsx
+++ b/src/components/Member/MemberList.tsx
@@ -35,6 +35,12 @@ const MemberList = ({
   const [isLoading, setIsLoading] = useState(false);
   const observerRef = useRef<HTMLDivElement | null>(null);
 
+  useEffect(() => {
+    setPageNumber(0);
+    setMembers([]);
+    setHasMore(true);
+  }, [selectedCardinal]);
+
   useGetAllUsers(
     selectedCardinal,
     pageNumber,

--- a/src/components/common/CardinalDropdown.tsx
+++ b/src/components/common/CardinalDropdown.tsx
@@ -64,10 +64,12 @@ const CardinalDropdown = ({
   const { allCardinals } = useGetAllCardinals();
 
   const options: { value: number | null; label: string }[] =
-    allCardinals?.map(({ id }) => ({
-      value: id,
-      label: `${id}기`,
-    })) || [];
+    allCardinals
+      ?.map(({ id }) => ({
+        value: id,
+        label: `${id}기`,
+      }))
+      .reverse() || [];
 
   if (isMember === true) options.unshift({ value: null, label: '전체' });
 

--- a/src/components/common/MenuModal.tsx
+++ b/src/components/common/MenuModal.tsx
@@ -3,21 +3,31 @@ import theme from '@/styles/theme';
 
 const Container = styled.div`
   position: absolute;
+  top: 0;
+  left: 0;
   z-index: 10;
   width: 100vw;
   height: 100vh;
+  // background-color: rgba(0, 0, 0, 0.5);
 `;
 
-const Content = styled.div<{ top?: number; right?: number }>`
+const ModalContainer = styled.div`
+  width: 370px;
+  position: fixed;
+  top: 55px;
+  left: 50%;
+  transform: translate(-50%);
+`;
+
+const Content = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
 
-  // position: absolute;
-  // top: ${({ top }) => (top ? `${top}px` : 0)};
-  // right: ${({ right }) => (right ? `${right}px` : 0)};
   width: 144px;
   box-sizing: border-box;
+  margin-left: auto;
+  margin-right: 18px;
 
   background-color: ${theme.color.gray[18]};
   border-radius: 10px;
@@ -28,19 +38,15 @@ const Content = styled.div<{ top?: number; right?: number }>`
 const MenuModal = ({
   children,
   onClose,
-  top,
-  right,
 }: {
   children: React.ReactNode;
   onClose?: () => void;
-  top?: number;
-  right?: number;
 }) => {
   return (
     <Container onClick={onClose}>
-      <Content onClick={(e) => e.stopPropagation()} top={top} right={right}>
-        {children}
-      </Content>
+      <ModalContainer>
+        <Content onClick={(e) => e.stopPropagation()}>{children}</Content>
+      </ModalContainer>
     </Container>
   );
 };

--- a/src/pages/BoardPostDetail.tsx
+++ b/src/pages/BoardPostDetail.tsx
@@ -110,8 +110,6 @@ const BoardPostDetail = () => {
           onClose={() => {
             setIsModalOpen(false);
           }}
-          top={55}
-          right={20}
         >
           <TextButton
             onClick={() => {

--- a/src/pages/Member.tsx
+++ b/src/pages/Member.tsx
@@ -9,6 +9,7 @@ import styled from 'styled-components';
 import search from '@/assets/images/ic_search.svg';
 import getSearchMember from '@/api/getSearchMember';
 import { User } from '@/types/user';
+import { toastError } from '@/components/common/ToastMessage';
 
 const Wrapper = styled.div`
   width: 370px;
@@ -61,6 +62,8 @@ const Member = () => {
       setSearchResults(response.data.data);
       navigate(`/member?search=${keyword}`);
     } catch (error) {
+      toastError('데이터를 불러오지 못했습니다.');
+      // eslint-disable-next-line no-console
       console.error(error);
     }
   };
@@ -68,6 +71,12 @@ const Member = () => {
   useEffect(() => {
     navigate(`/member?cardinal=${selectedCardinal}`);
   }, [selectedCardinal]);
+
+  const handleEnter = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      handleSearch();
+    }
+  };
 
   return (
     <Wrapper>
@@ -84,6 +93,7 @@ const Member = () => {
           placeholder="멤버 이름을 검색하세요"
           value={keyword}
           onChange={(e) => setKeyword(e.target.value)}
+          onKeyDown={handleEnter}
         />
         <SearchButton src={search} alt={search} onClick={handleSearch} />
       </Search>

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -47,8 +47,6 @@ const MyPage = () => {
           onClose={() => {
             setIsModalOpen(false);
           }}
-          top={60}
-          right={620}
         >
           <S.TextButton
             onClick={() => {

--- a/src/pages/NoticePostDetail.tsx
+++ b/src/pages/NoticePostDetail.tsx
@@ -106,8 +106,6 @@ const NoticePostDetail = () => {
           onClose={() => {
             setIsModalOpen(false);
           }}
-          top={55}
-          right={20}
         >
           <TextButton onClick={() => navigate(`/board/${postId}/edit`)}>
             수정


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
#381 을 구현했습니다
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
기수 드롭다운이 height 제한이 없어 너무 길어져서,,, 우선 피그마에 남겨둔 상태입니다 ! 

<br>

## 3. 관련 스크린샷을 첨부해주세요.
<img width="612" alt="스크린샷 2025-02-26 오후 10 12 49" src="https://github.com/user-attachments/assets/72a11121-a3b6-42d5-b729-af4629de6ab5" />
<img width="612" alt="스크린샷 2025-02-26 오후 10 13 01" src="https://github.com/user-attachments/assets/ffa06837-cb6d-43fd-9bc0-4055be410f6e" />
<img width="612" alt="스크린샷 2025-02-26 오후 10 13 10" src="https://github.com/user-attachments/assets/9ae788b3-c449-4742-849f-577e205052df" />
<img width="612" alt="스크린샷 2025-02-26 오후 10 13 22" src="https://github.com/user-attachments/assets/d0fd054e-9b61-4d0e-9a3f-b93d4ffbaf48" />
<img width="400" alt="스크린샷 2025-02-26 오후 10 16 03" src="https://github.com/user-attachments/assets/05fdc0c1-4f55-43f4-95e1-1ab1024b5073" />

<br>

## 4. 완료 사항
- 메뉴모달 위치 수정
드디어 이 녀석을 해결했습니다,, Container 내부에 스타일드 컴포넌트를 하나 더 추가하여 `width: 370;` 설정을 추가하여 뒷배경은 전체를 유지한 채 모달만 370px 내에 위치하도록 했습니다! 이제 모든 페이지에서 같은 위치에 나타납니다....(´༎ຶོρ༎ຶོ`)
- 멤버 검색 시 마지막 멤버입니다. 뜨지 않도록
- 멤버 검색 시 엔터로 검색
- 멤버 기수별 조회 안되는 오류 수정
- 기수 드롭다운 내림차순으로 수정
<br>

## 5. 추가 사항

<br>
