### PR TITLE
#377 Refactor: 기수 관련 UI 수정 및 추가 api 연결

### DIFF
--- a/src/api/admin/cardinal/postCardinal.ts
+++ b/src/api/admin/cardinal/postCardinal.ts
@@ -3,6 +3,7 @@ import axios from 'axios';
 const BASE_URL = import.meta.env.VITE_API_URL;
 const PATH = '/api/v1/admin/cardinals';
 
+// 새로운 기수 등록
 const postCardinalApi = async (
   cardinalNumber: number,
   year: number,
@@ -27,4 +28,30 @@ const postCardinalApi = async (
   }
 };
 
-export default postCardinalApi;
+// 기수 수정
+const patchCardinalApi = async (
+  id: number,
+  year: number,
+  semester: number,
+  inProgress: boolean,
+) => {
+  const accessToken = localStorage.getItem('accessToken');
+
+  try {
+    const response = await axios.patch(
+      `${BASE_URL}${PATH}`,
+      { id, year, semester, inProgress },
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      },
+    );
+
+    return response.data;
+  } catch (error: any) {
+    throw new Error(error.response?.data?.message || '기수 수정 실패');
+  }
+};
+
+export { patchCardinalApi, postCardinalApi };

--- a/src/api/admin/cardinal/postCardinal.ts
+++ b/src/api/admin/cardinal/postCardinal.ts
@@ -8,13 +8,14 @@ const postCardinalApi = async (
   cardinalNumber: number,
   year: number,
   semester: number,
+  inProgress: boolean,
 ) => {
   const accessToken = localStorage.getItem('accessToken');
 
   try {
     const response = await axios.post(
       `${BASE_URL}${PATH}`,
-      { cardinalNumber, year, semester },
+      { cardinalNumber, year, semester, inProgress },
       {
         headers: {
           Authorization: `Bearer ${accessToken}`,

--- a/src/api/useGetCardinals.tsx
+++ b/src/api/useGetCardinals.tsx
@@ -17,7 +17,11 @@ export const getAllCardinals = async () => {
 
 export const useGetAllCardinals = () => {
   const [allCardinals, setAllCardinals] = useState<
-    { id: number; cardinalNumber: number }[]
+    {
+      status: string; // 현재 기수인지 아닌지 값 추가
+      id: number;
+      cardinalNumber: number;
+    }[]
   >([]);
   const [error, setError] = useState<string | null>(null);
 

--- a/src/api/useGetCardinals.tsx
+++ b/src/api/useGetCardinals.tsx
@@ -32,6 +32,7 @@ export const useGetAllCardinals = () => {
       try {
         const response = await getAllCardinals();
         setAllCardinals(response.data.data);
+        console.log('기수 응답: ', response.data);
       } catch (err: any) {
         setError(
           err.response?.data?.message ||

--- a/src/api/useGetCardinals.tsx
+++ b/src/api/useGetCardinals.tsx
@@ -32,7 +32,6 @@ export const useGetAllCardinals = () => {
       try {
         const response = await getAllCardinals();
         setAllCardinals(response.data.data);
-        console.log('기수 응답: ', response.data);
       } catch (err: any) {
         setError(
           err.response?.data?.message ||

--- a/src/api/useGetCardinals.tsx
+++ b/src/api/useGetCardinals.tsx
@@ -18,7 +18,7 @@ export const getAllCardinals = async () => {
 export const useGetAllCardinals = () => {
   const [allCardinals, setAllCardinals] = useState<
     {
-      status: string; // 현재 기수인지 아닌지 값 추가
+      status: string; // 기수 상태값 추가 ( IN_PROGRESS 이면 현재 기수 )
       id: number;
       cardinalNumber: number;
     }[]

--- a/src/components/Admin/Box.tsx
+++ b/src/components/Admin/Box.tsx
@@ -12,6 +12,7 @@ export interface BoxProps {
   onClick?: () => void;
   isClick?: boolean;
   isSelected?: boolean;
+  isIncomplete?: boolean;
 }
 
 export const Wrapper = styled.div<{
@@ -19,12 +20,18 @@ export const Wrapper = styled.div<{
   isCardinalBox: boolean;
   isClick?: boolean;
   isSelected?: boolean;
+  isIncomplete?: boolean;
 }>`
   width: ${({ isCardinalBox }) => (isCardinalBox ? 'none' : '234px')};
   min-width: ${({ isCardinalBox }) => (isCardinalBox ? '234px' : 'none')};
   height: 164px;
-  background-color: ${({ isSelected, color }) =>
-    isSelected ? theme.color.gray[18] : color};
+  background-color: ${({ isIncomplete, isSelected, color }) => {
+    if (isIncomplete) return 'transparent';
+    if (isSelected) return theme.color.gray[18];
+    return color;
+  }};
+  border: ${({ isIncomplete }) =>
+    isIncomplete ? `1.5px dashed ${theme.color.gray[18]}` : 'none'};
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -32,9 +39,10 @@ export const Wrapper = styled.div<{
   box-sizing: border-box;
   cursor: ${({ isClick }) => (isClick ? 'pointer' : 'auto')};
 
-  ${({ isClick, isSelected }) =>
+  ${({ isClick, isSelected, isIncomplete }) =>
     isClick &&
     !isSelected &&
+    !isIncomplete &&
     `
     &:hover {
       background-color: ${theme.color.gray[18]};
@@ -42,23 +50,29 @@ export const Wrapper = styled.div<{
   `}
 `;
 
-export const Title = styled.div<{ isHidden?: boolean }>`
+export const Title = styled.div<{
+  isHidden?: boolean;
+  isIncomplete?: boolean;
+}>`
   font-size: 18px;
   font-family: ${theme.font.regular};
-  color: ${theme.color.gray[100]};
+  color: ${({ isIncomplete }) =>
+    isIncomplete ? theme.color.gray[18] : theme.color.gray[100]};
 `;
 
-export const Description = styled.div`
+export const Description = styled.div<{ isIncomplete?: boolean }>`
   font-size: 24px;
   font-family: ${theme.font.semiBold};
-  color: ${theme.color.gray[100]};
+  color: ${({ isIncomplete }) =>
+    isIncomplete ? theme.color.gray[18] : theme.color.gray[100]};
   margin-top: 20px;
 `;
 
-export const Last = styled.div<{ lastColor?: string }>`
+export const Last = styled.div<{ lastColor?: string; isIncomplete?: boolean }>`
   font-size: 18px;
   font-family: ${theme.font.regular};
-  color: ${({ lastColor }) => lastColor || '#979797'};
+  color: ${({ isIncomplete, lastColor }) =>
+    isIncomplete ? '#909393' : lastColor || '#979797'};
 `;
 
 const Box: React.FC<BoxProps> = ({
@@ -71,6 +85,7 @@ const Box: React.FC<BoxProps> = ({
   onClick,
   isClick = false,
   isSelected = false,
+  isIncomplete = false,
 }) => {
   return (
     <Wrapper
@@ -79,10 +94,13 @@ const Box: React.FC<BoxProps> = ({
       isCardinalBox={isCardinalBox}
       isClick={isClick}
       isSelected={isSelected}
+      isIncomplete={isIncomplete}
     >
-      {title && <Title>{title}</Title>}
-      <Description>{description}</Description>
-      <Last lastColor={lastColor}>{last}</Last>
+      {title && <Title isIncomplete={isIncomplete}>{title}</Title>}
+      <Description isIncomplete={isIncomplete}>{description}</Description>
+      <Last lastColor={lastColor} isIncomplete={isIncomplete}>
+        {last}
+      </Last>
     </Wrapper>
   );
 };

--- a/src/components/Admin/Box.tsx
+++ b/src/components/Admin/Box.tsx
@@ -9,21 +9,37 @@ export interface BoxProps {
   lastColor?: string;
   minWidth?: string;
   isCardinalBox?: boolean;
+  onClick?: () => void;
+  isClick?: boolean;
+  isSelected?: boolean;
 }
 
 export const Wrapper = styled.div<{
   color: string;
   isCardinalBox: boolean;
+  isClick?: boolean;
+  isSelected?: boolean;
 }>`
   width: ${({ isCardinalBox }) => (isCardinalBox ? 'none' : '234px')};
   min-width: ${({ isCardinalBox }) => (isCardinalBox ? '234px' : 'none')};
   height: 164px;
-  background-color: ${(props) => props.color};
+  background-color: ${({ isSelected, color }) =>
+    isSelected ? theme.color.gray[18] : color};
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   padding: 16px;
   box-sizing: border-box;
+  cursor: ${({ isClick }) => (isClick ? 'pointer' : 'auto')};
+
+  ${({ isClick, isSelected }) =>
+    isClick &&
+    !isSelected &&
+    `
+    &:hover {
+      background-color: ${theme.color.gray[18]};
+    }
+  `}
 `;
 
 export const Title = styled.div<{ isHidden?: boolean }>`
@@ -52,9 +68,18 @@ const Box: React.FC<BoxProps> = ({
   color,
   lastColor,
   isCardinalBox = false,
+  onClick,
+  isClick = false,
+  isSelected = false,
 }) => {
   return (
-    <Wrapper color={color} isCardinalBox={isCardinalBox}>
+    <Wrapper
+      onClick={onClick}
+      color={color}
+      isCardinalBox={isCardinalBox}
+      isClick={isClick}
+      isSelected={isSelected}
+    >
       {title && <Title>{title}</Title>}
       <Description>{description}</Description>
       <Last lastColor={lastColor}>{last}</Last>

--- a/src/components/Admin/ButtonGroup.tsx
+++ b/src/components/Admin/ButtonGroup.tsx
@@ -18,10 +18,9 @@ const ButtonGroupContainer = styled.div<{ hasEndGap?: boolean }>`
   justify-content: center;
   align-items: center;
   gap: 12px;
-  padding-right: 20px;
+  padding: 10px;
   overflow-x: auto;
   white-space: nowrap;
-  padding-left: 10px;
   &::-webkit-scrollbar {
     height: 3px;
   }
@@ -30,7 +29,7 @@ const ButtonGroupContainer = styled.div<{ hasEndGap?: boolean }>`
     hasEndGap &&
     `
     & > :last-child {
-    margin-left:150px
+    margin-left:188px
     }
 
       @media (max-width: 900px) {

--- a/src/components/Admin/CardinalInfo.tsx
+++ b/src/components/Admin/CardinalInfo.tsx
@@ -4,10 +4,16 @@ import AddCardinal from '@/components/Admin/AddCardinal';
 import useGetAllCardinals from '@/api/useGetCardinals';
 import { useEffect, useState } from 'react';
 import { useGetAdminUsers } from '@/api/admin/member/getAdminUser';
+import { useMemberContext } from './context/MemberContext';
 
 const CardinalInfo: React.FC = () => {
+  const { selectedCardinal, setSelectedCardinal } = useMemberContext();
   const { allCardinals } = useGetAllCardinals();
   const { allUsers } = useGetAdminUsers();
+  const [currentEditingCardinal, setCurrentEditingCardinal] = useState<{
+    id: number;
+    cardinalNumber: number;
+  } | null>(null);
   const [cardinalList, setCardinalList] = useState<
     { id: number; year?: number; semester?: number; cardinalNumber: number }[]
   >([]);
@@ -27,6 +33,20 @@ const CardinalInfo: React.FC = () => {
 
   const totalMembers = allUsers.length;
 
+  const handleCardinalClick = (cardinal: {
+    id: number;
+    year?: number;
+    semester?: number;
+    cardinalNumber: number;
+  }) => {
+    console.log('클릭된 기수:', cardinal.cardinalNumber);
+    if (!cardinal.year || !cardinal.semester) {
+      setCurrentEditingCardinal(cardinal);
+      // setIsModalOpen(true)
+    } else {
+      setSelectedCardinal(cardinal.cardinalNumber);
+    }
+  };
   return (
     <S.CardinalBoxWrapper>
       <S.ScrollContainer>
@@ -38,6 +58,8 @@ const CardinalInfo: React.FC = () => {
           color={theme.color.gray[18]}
           lastColor="#D3D3D3"
           isCardinalBox
+          isClick
+          onClick={() => setSelectedCardinal(null)}
         />
         {cardinalList.map((cardinal) => {
           const memberCount = getMemberCountByCardinal(cardinal.cardinalNumber);
@@ -55,6 +77,9 @@ const CardinalInfo: React.FC = () => {
               color={theme.color.gray[65]}
               lastColor="#D3D3D3"
               isCardinalBox
+              isClick
+              isSelected={selectedCardinal === cardinal.cardinalNumber}
+              onClick={() => handleCardinalClick(cardinal)}
             />
           );
         })}

--- a/src/components/Admin/CardinalInfo.tsx
+++ b/src/components/Admin/CardinalInfo.tsx
@@ -1,16 +1,18 @@
 import theme from '@/styles/theme';
+import Box from '@/components/Admin/Box';
 import * as S from '@/styles/admin/cardinal/CardinalInfo.styled';
 import AddCardinal from '@/components/Admin/AddCardinal';
 import useGetAllCardinals from '@/api/useGetCardinals';
 import { useEffect, useState } from 'react';
 import { useGetAdminUsers } from '@/api/admin/member/getAdminUser';
-import { useMemberContext } from './context/MemberContext';
-import Box from './Box';
+import { useMemberContext } from '@/components/Admin/context/MemberContext';
+import CardinalModal from '@/components/Admin/Modal/CardinalModal';
 
 const CardinalInfo: React.FC = () => {
   const { selectedCardinal, setSelectedCardinal } = useMemberContext();
   const { allCardinals } = useGetAllCardinals();
   const { allUsers } = useGetAdminUsers();
+  const [isModalOpen, setIsModalOpen] = useState(false);
   const [currentEditingCardinal, setCurrentEditingCardinal] = useState<{
     id: number;
     cardinalNumber: number;
@@ -48,7 +50,7 @@ const CardinalInfo: React.FC = () => {
   }) => {
     if (!cardinal.year || !cardinal.semester) {
       setCurrentEditingCardinal(cardinal);
-      // setIsModalOpen(true)
+      setIsModalOpen(true);
     } else {
       setSelectedCardinal(cardinal.cardinalNumber);
     }
@@ -96,6 +98,13 @@ const CardinalInfo: React.FC = () => {
             />
           );
         })}
+        {isModalOpen && currentEditingCardinal && (
+          <CardinalModal
+            isOpen={isModalOpen}
+            onClose={() => setIsModalOpen(false)}
+            initialCardinal={currentEditingCardinal}
+          />
+        )}
       </S.ScrollContainer>
     </S.CardinalBoxWrapper>
   );

--- a/src/components/Admin/CardinalInfo.tsx
+++ b/src/components/Admin/CardinalInfo.tsx
@@ -103,6 +103,7 @@ const CardinalInfo: React.FC = () => {
             isOpen={isModalOpen}
             onClose={() => setIsModalOpen(false)}
             initialCardinal={currentEditingCardinal}
+            setCardinalList={setCardinalList}
           />
         )}
       </S.ScrollContainer>

--- a/src/components/Admin/CardinalInfo.tsx
+++ b/src/components/Admin/CardinalInfo.tsx
@@ -5,6 +5,7 @@ import useGetAllCardinals from '@/api/useGetCardinals';
 import { useEffect, useState } from 'react';
 import { useGetAdminUsers } from '@/api/admin/member/getAdminUser';
 import { useMemberContext } from './context/MemberContext';
+import Box from './Box';
 
 const CardinalInfo: React.FC = () => {
   const { selectedCardinal, setSelectedCardinal } = useMemberContext();
@@ -74,15 +75,22 @@ const CardinalInfo: React.FC = () => {
               : `노정완 외 ${memberCount}명`;
 
           return (
-            <S.CardinalBox
+            <Box
               key={cardinal.id}
-              title={`${cardinal.year}년 ${cardinal.semester}학기 ${cardinal.status === 'IN_PROGRESS' ? '(현재)' : ''}`}
+              title={
+                cardinal.year && cardinal.semester
+                  ? `${cardinal.year}년 ${cardinal.semester}학기 ${
+                      cardinal.status === 'IN_PROGRESS' ? '(현재)' : ''
+                    }`
+                  : '정보를 입력해주세요'
+              }
               description={`${cardinal.cardinalNumber}기`}
               last={lastText}
               color={theme.color.gray[65]}
               lastColor="#D3D3D3"
               isCardinalBox
               isClick
+              isIncomplete={!cardinal.year || !cardinal.semester}
               isSelected={selectedCardinal === cardinal.cardinalNumber}
               onClick={() => handleCardinalClick(cardinal)}
             />

--- a/src/components/Admin/CardinalInfo.tsx
+++ b/src/components/Admin/CardinalInfo.tsx
@@ -15,7 +15,13 @@ const CardinalInfo: React.FC = () => {
     cardinalNumber: number;
   } | null>(null);
   const [cardinalList, setCardinalList] = useState<
-    { id: number; year?: number; semester?: number; cardinalNumber: number }[]
+    {
+      id: number;
+      year?: number;
+      semester?: number;
+      cardinalNumber: number;
+      status?: string;
+    }[]
   >([]);
 
   useEffect(() => {
@@ -70,7 +76,7 @@ const CardinalInfo: React.FC = () => {
           return (
             <S.CardinalBox
               key={cardinal.id}
-              title={`${cardinal.year}년 ${cardinal.semester}학기`}
+              title={`${cardinal.year}년 ${cardinal.semester}학기 ${cardinal.status === 'IN_PROGRESS' ? '(현재)' : ''}`}
               description={`${cardinal.cardinalNumber}기`}
               last={lastText}
               color={theme.color.gray[65]}

--- a/src/components/Admin/CardinalInfo.tsx
+++ b/src/components/Admin/CardinalInfo.tsx
@@ -39,7 +39,6 @@ const CardinalInfo: React.FC = () => {
     semester?: number;
     cardinalNumber: number;
   }) => {
-    console.log('클릭된 기수:', cardinal.cardinalNumber);
     if (!cardinal.year || !cardinal.semester) {
       setCurrentEditingCardinal(cardinal);
       // setIsModalOpen(true)

--- a/src/components/Admin/CardinalSearchBar.tsx
+++ b/src/components/Admin/CardinalSearchBar.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction, useState } from 'react';
+import React, { Dispatch, SetStateAction } from 'react';
 import CardinalDropDown from '@/components/Admin/Cardinal';
 import SearchBar, { SearchBarWrapper } from '@/components/Admin/SearchBar';
 
@@ -7,17 +7,16 @@ interface CombinedSearchBarProps {
   setSelectedCardinal: Dispatch<SetStateAction<number | null>>;
 }
 
-const CombinedSearchBar: React.FC<CombinedSearchBarProps> = () => {
-  const [selectedCardinal, setSelectedCardinal] = useState<null | number>(null);
-
+const CombinedSearchBar: React.FC<CombinedSearchBarProps> = ({
+  selectedCardinal,
+  setSelectedCardinal,
+}) => {
   return (
     <SearchBarWrapper>
       <div>
         <CardinalDropDown
           selectedCardinal={selectedCardinal}
-          setSelectedCardinal={(value) => {
-            setSelectedCardinal(value);
-          }}
+          setSelectedCardinal={setSelectedCardinal}
         />
       </div>
       <SearchBar isWrapped={false} />

--- a/src/components/Admin/DirectCardinal.tsx
+++ b/src/components/Admin/DirectCardinal.tsx
@@ -21,7 +21,7 @@ const DirectCardinalDropdown: React.FC<DirectCardinalProps> = ({
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const { allCardinals } = useGetAllCardinals();
-  const [isCustomInput] = useState(false);
+  const [isCustomInput, setIsCustomInput] = useState(false);
 
   const sortedCardinals = [...allCardinals].reverse();
 
@@ -29,17 +29,18 @@ const DirectCardinalDropdown: React.FC<DirectCardinalProps> = ({
 
   const selectCardinal = (value: number) => {
     setSelectedCardinal(value, false);
+    setIsCustomInput(false);
     setIsOpen(false);
   };
 
   const handleCustomInput = () => {
     setSelectedCardinal(0, true);
+    setIsCustomInput(true);
     setIsOpen(false);
   };
 
   const getDisplayText = () => {
-    if (isCustomInput || selectedCardinal === 0 || selectedCardinal === null)
-      return '직접 입력';
+    if (isCustomInput || selectedCardinal === null) return '직접 입력';
     return `${selectedCardinal}기`;
   };
 

--- a/src/components/Admin/Modal/CardinalEditModal.tsx
+++ b/src/components/Admin/Modal/CardinalEditModal.tsx
@@ -5,7 +5,7 @@ import CommonCardinalModal from '@/components/Admin/Modal/CommonCardinalModal';
 import DirectCardinalDropdown from '@/components/Admin/DirectCardinal';
 import { continueNextCardinalApi } from '@/api/admin/member/patchUserManagement';
 import useGetAllCardinals from '@/api/useGetCardinals';
-import { patchCardinalApi } from '@/api/admin/cardinal/postCardinal';
+// import { patchCardinalApi } from '@/api/admin/cardinal/postCardinal';
 
 interface CardinalChangeModalProps {
   isOpen: boolean;
@@ -28,7 +28,7 @@ const CardinalEditModal: React.FC<CardinalChangeModalProps> = ({
 }) => {
   const [cardinalNumber, setCardinalNumber] = useState('');
   const [isCustomInput, setIsCustomInput] = useState(false);
-  const [selectedCardinal] = useState<number | null>(null);
+  const [selectedCardinal, setSelectedCardinal] = useState<number | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const { allCardinals } = useGetAllCardinals();
@@ -38,9 +38,11 @@ const CardinalEditModal: React.FC<CardinalChangeModalProps> = ({
     setIsCustomInput(isCustom);
     if (isCustom) {
       setCardinalNumber('');
+      setSelectedCardinal(null);
       setTimeout(() => inputRef.current?.focus(), 0);
     } else {
       setCardinalNumber(String(value));
+      setSelectedCardinal(value);
     }
   };
 

--- a/src/components/Admin/Modal/CardinalEditModal.tsx
+++ b/src/components/Admin/Modal/CardinalEditModal.tsx
@@ -4,6 +4,8 @@ import * as S from '@/styles/admin/cardinal/CardinalModal.styled';
 import CommonCardinalModal from '@/components/Admin/Modal/CommonCardinalModal';
 import DirectCardinalDropdown from '@/components/Admin/DirectCardinal';
 import { continueNextCardinalApi } from '@/api/admin/member/patchUserManagement';
+import useGetAllCardinals from '@/api/useGetCardinals';
+import { patchCardinalApi } from '@/api/admin/cardinal/postCardinal';
 
 interface CardinalChangeModalProps {
   isOpen: boolean;
@@ -27,8 +29,10 @@ const CardinalEditModal: React.FC<CardinalChangeModalProps> = ({
   const [cardinalNumber, setCardinalNumber] = useState('');
   const [isCustomInput, setIsCustomInput] = useState(false);
   const [selectedCardinal] = useState<number | null>(null);
-
   const inputRef = useRef<HTMLInputElement>(null);
+
+  const { allCardinals } = useGetAllCardinals();
+  const existingCardinalNumbers = allCardinals.map((c) => c.cardinalNumber);
 
   const handleSelectCardinal = (value: number, isCustom: boolean) => {
     setIsCustomInput(isCustom);
@@ -47,6 +51,16 @@ const CardinalEditModal: React.FC<CardinalChangeModalProps> = ({
     }
 
     try {
+      const newCardinalNumber = Number(cardinalNumber);
+
+      const isExistingCardinal =
+        existingCardinalNumbers.includes(newCardinalNumber);
+
+      if (isCustomInput && isExistingCardinal) {
+        alert('이미 존재하는 기수입니다.');
+        return;
+      }
+
       const cardinalData = selectedUserIds.map((id) => ({
         userId: id,
         cardinal: Number(cardinalNumber),

--- a/src/components/Admin/Modal/CardinalEditModal.tsx
+++ b/src/components/Admin/Modal/CardinalEditModal.tsx
@@ -5,7 +5,6 @@ import CommonCardinalModal from '@/components/Admin/Modal/CommonCardinalModal';
 import DirectCardinalDropdown from '@/components/Admin/DirectCardinal';
 import { continueNextCardinalApi } from '@/api/admin/member/patchUserManagement';
 import useGetAllCardinals from '@/api/useGetCardinals';
-// import { patchCardinalApi } from '@/api/admin/cardinal/postCardinal';
 
 interface CardinalChangeModalProps {
   isOpen: boolean;

--- a/src/components/Admin/Modal/CardinalModal.tsx
+++ b/src/components/Admin/Modal/CardinalModal.tsx
@@ -5,7 +5,7 @@ import CheckBox from '@/assets/images/ic_admin_checkbox.svg';
 import UnCheckBox from '@/assets/images/ic_admin_uncheckbox.svg';
 import * as S from '@/styles/admin/cardinal/CardinalModal.styled';
 import CommonCardinalModal from '@/components/Admin/Modal/CommonCardinalModal';
-import postCardinalApi from '@/api/admin/cardinal/postCardinal';
+import { postCardinalApi } from '@/api/admin/cardinal/postCardinal';
 import {
   handleNumericInput,
   preventNonNumeric,

--- a/src/components/Admin/Modal/CardinalModal.tsx
+++ b/src/components/Admin/Modal/CardinalModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import Button from '@/components/Button/Button';
 import CheckBox from '@/assets/images/ic_admin_checkbox.svg';
@@ -22,6 +22,7 @@ interface CardinalModalProps {
     cardinalNumber: number;
     year?: number;
     semester?: number;
+    status?: string;
   };
   cardinalList: {
     id: number;
@@ -57,15 +58,17 @@ const CardinalModal: React.FC<CardinalModalProps> = ({
   onClose,
   initialCardinal,
   cardinalList,
-  setCardinalList,
+  setCardinalList = () => {},
 }) => {
   const isEditing = Boolean(initialCardinal);
+
+  const [, setCardinals] = useState(cardinalList);
 
   const [formState, setFormState] = useState({
     cardinalNumber: initialCardinal?.cardinalNumber || '',
     year: initialCardinal?.year || '',
     semester: initialCardinal?.semester || '',
-    isChecked: false,
+    isChecked: initialCardinal?.status === 'IN_PROGRESS' || false,
   });
 
   const handleCheckBoxClick = () => {
@@ -84,7 +87,13 @@ const CardinalModal: React.FC<CardinalModalProps> = ({
     }
 
     try {
-      let updatedCardinal: { id: number };
+      let updatedCardinal: {
+        id: number;
+        year?: number;
+        semester?: number;
+        cardinalNumber: number;
+        status?: string;
+      };
 
       if (isEditing && initialCardinal?.id) {
         // 기수 수정 api 호출
@@ -120,12 +129,15 @@ const CardinalModal: React.FC<CardinalModalProps> = ({
       }
 
       onClose();
-      window.location.reload();
     } catch (error: any) {
       console.error('새로운 기수 저장 실패:', error.message);
       alert(`기수 저장 실패: ${error.message}`);
     }
   };
+
+  useEffect(() => {
+    setCardinals(cardinalList);
+  }, [cardinalList]);
 
   return (
     <CommonCardinalModal

--- a/src/components/Admin/Modal/CardinalModal.tsx
+++ b/src/components/Admin/Modal/CardinalModal.tsx
@@ -87,6 +87,7 @@ const CardinalModal: React.FC<CardinalModalProps> = ({
       }
 
       onClose();
+      window.location.reload();
     } catch (error: any) {
       console.error('새로운 기수 저장 실패:', error.message);
       alert(`기수 저장 실패: ${error.message}`);

--- a/src/components/Admin/Modal/CardinalModal.tsx
+++ b/src/components/Admin/Modal/CardinalModal.tsx
@@ -23,6 +23,24 @@ interface CardinalModalProps {
     year?: number;
     semester?: number;
   };
+  cardinalList: {
+    id: number;
+    year?: number;
+    semester?: number;
+    cardinalNumber: number;
+    status?: string;
+  }[];
+  setCardinalList: React.Dispatch<
+    React.SetStateAction<
+      {
+        id: number;
+        year?: number;
+        semester?: number;
+        cardinalNumber: number;
+        status?: string;
+      }[]
+    >
+  >;
 }
 
 export const ModalContentWrapper = styled.div`
@@ -38,6 +56,8 @@ const CardinalModal: React.FC<CardinalModalProps> = ({
   isOpen,
   onClose,
   initialCardinal,
+  cardinalList,
+  setCardinalList,
 }) => {
   const isEditing = Boolean(initialCardinal);
 
@@ -64,6 +84,8 @@ const CardinalModal: React.FC<CardinalModalProps> = ({
     }
 
     try {
+      let updatedCardinal: { id: number };
+
       if (isEditing && initialCardinal?.id) {
         // 기수 수정 api 호출
         const response = await patchCardinalApi(
@@ -74,6 +96,14 @@ const CardinalModal: React.FC<CardinalModalProps> = ({
         );
         console.log('기수 수정 성공:', response);
         alert('기수 정보가 수정되었습니다.');
+        updatedCardinal = response.data;
+        setCardinalList((prev) =>
+          prev.map((cardinal) =>
+            cardinal.id === updatedCardinal.id
+              ? { ...cardinal, ...updatedCardinal }
+              : cardinal,
+          ),
+        );
       } else {
         // 기수 추가 api 호출
         const response = await postCardinalApi(
@@ -84,6 +114,9 @@ const CardinalModal: React.FC<CardinalModalProps> = ({
         );
         console.log('새로운 기수 저장 성공:', response);
         alert('새로운 기수가 저장되었습니다.');
+        updatedCardinal = response.data;
+
+        setCardinalList((prev) => [...prev, { ...updatedCardinal }]);
       }
 
       onClose();

--- a/src/components/Admin/Modal/CardinalModal.tsx
+++ b/src/components/Admin/Modal/CardinalModal.tsx
@@ -6,6 +6,10 @@ import UnCheckBox from '@/assets/images/ic_admin_uncheckbox.svg';
 import * as S from '@/styles/admin/cardinal/CardinalModal.styled';
 import CommonCardinalModal from '@/components/Admin/Modal/CommonCardinalModal';
 import postCardinalApi from '@/api/admin/cardinal/postCardinal';
+import {
+  handleNumericInput,
+  preventNonNumeric,
+} from '@/utils/admin/handleNumericInput';
 
 interface CardinalModalProps {
   isOpen: boolean;
@@ -13,11 +17,12 @@ interface CardinalModalProps {
 }
 
 export const ModalContentWrapper = styled.div`
-  padding: 10px;
+  padding: 5px 20px;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   gap: 20px;
+  box-sizing: border-box;
 `;
 
 const CardinalModal: React.FC<CardinalModalProps> = ({ isOpen, onClose }) => {
@@ -27,14 +32,6 @@ const CardinalModal: React.FC<CardinalModalProps> = ({ isOpen, onClose }) => {
     semester: '',
     isChecked: false,
   });
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = e.target;
-    setFormState((prev) => ({
-      ...prev,
-      [name]: value,
-    }));
-  };
 
   const handleCheckBoxClick = () => {
     setFormState((prev) => ({
@@ -91,30 +88,41 @@ const CardinalModal: React.FC<CardinalModalProps> = ({ isOpen, onClose }) => {
     >
       <ModalContentWrapper>
         <S.Title>새로운 기수 추가</S.Title>
-        <div>추가할 새로운 기수를 작성해주세요</div>
-        <S.Input
-          type="text"
-          name="cardinalNumber"
-          value={formState.cardinalNumber}
-          onChange={handleChange}
-        />
-        <div>기</div>
-        <div>활동 시기</div>
+        <li>추가할 새로운 기수를 작성해주세요</li>
+        <S.InputWrapper>
+          <S.Input
+            type="text"
+            name="cardinalNumber"
+            value={formState.cardinalNumber}
+            onChange={(e) => handleNumericInput(e, setFormState, 2)}
+            onKeyDown={preventNonNumeric}
+          />
+          <S.Unit>기</S.Unit>
+        </S.InputWrapper>
+        <li>활동 시기</li>
         <S.FlexRow>
-          <S.Input
-            type="text"
-            name="year"
-            value={formState.year}
-            onChange={handleChange}
-          />
-          <div>년</div>
-          <S.Input
-            type="text"
-            name="semester"
-            value={formState.semester}
-            onChange={handleChange}
-          />
-          <div>학기</div>
+          <S.InputWrapper>
+            <S.Input
+              type="text"
+              name="year"
+              value={formState.year}
+              onChange={(e) => handleNumericInput(e, setFormState, 4)}
+              onKeyDown={preventNonNumeric}
+            />
+            <S.Unit>년</S.Unit>
+          </S.InputWrapper>
+          <S.InputWrapper>
+            <S.Input
+              type="text"
+              name="semester"
+              value={formState.semester}
+              onChange={(e) =>
+                handleNumericInput(e, setFormState, 1, ['1', '2'])
+              }
+              onKeyDown={preventNonNumeric}
+            />
+            <S.Unit>학기</S.Unit>
+          </S.InputWrapper>
         </S.FlexRow>
         <S.SvgText onClick={handleCheckBoxClick}>
           <img

--- a/src/components/Admin/Modal/CardinalModal.tsx
+++ b/src/components/Admin/Modal/CardinalModal.tsx
@@ -41,7 +41,7 @@ const CardinalModal: React.FC<CardinalModalProps> = ({ isOpen, onClose }) => {
   };
 
   const handleClick = async () => {
-    const { cardinalNumber, year, semester } = formState;
+    const { cardinalNumber, year, semester, isChecked } = formState;
 
     if (!cardinalNumber || !year || !semester) {
       alert('모든 필드를 입력해주세요.');
@@ -53,6 +53,7 @@ const CardinalModal: React.FC<CardinalModalProps> = ({ isOpen, onClose }) => {
         Number(cardinalNumber),
         Number(year),
         Number(semester),
+        isChecked,
       );
       console.log('새로운 기수 저장 성공:', response);
       alert('새로운 기수가 저장되었습니다.');

--- a/src/components/Admin/Modal/CardinalModal.tsx
+++ b/src/components/Admin/Modal/CardinalModal.tsx
@@ -90,30 +90,31 @@ const CardinalModal: React.FC<CardinalModalProps> = ({ isOpen, onClose }) => {
       }
     >
       <ModalContentWrapper>
-        <S.Title>추가할 새로운 기수를 작성해주세요</S.Title>
+        <S.Title>새로운 기수 추가</S.Title>
+        <div>추가할 새로운 기수를 작성해주세요</div>
         <S.Input
           type="text"
-          placeholder="기"
           name="cardinalNumber"
           value={formState.cardinalNumber}
           onChange={handleChange}
         />
+        <div>기</div>
         <div>활동 시기</div>
         <S.FlexRow>
           <S.Input
             type="text"
-            placeholder="년"
             name="year"
             value={formState.year}
             onChange={handleChange}
           />
+          <div>년</div>
           <S.Input
             type="text"
-            placeholder="학기"
             name="semester"
             value={formState.semester}
             onChange={handleChange}
           />
+          <div>학기</div>
         </S.FlexRow>
         <S.SvgText onClick={handleCheckBoxClick}>
           <img

--- a/src/components/Admin/Modal/CommonCardinalModal.tsx
+++ b/src/components/Admin/Modal/CommonCardinalModal.tsx
@@ -38,6 +38,8 @@ const CommonCardinalModal: React.FC<CommonCardinalModalProps> = ({
     <Modal
       isOpen={isOpen}
       onRequestClose={onClose}
+      className="common-cardinal-modal"
+      portalClassName="common-cardinal-modal-root"
       style={{
         overlay: { backgroundColor: 'transparent' },
         content: { inset: 'unset' },

--- a/src/components/Admin/Modal/MemberDetailModal.tsx
+++ b/src/components/Admin/Modal/MemberDetailModal.tsx
@@ -16,12 +16,20 @@ interface MemberDetailModalProps {
 const getHighestCardinal = (cardinals: number[] | undefined | null): string => {
   console.log('기수 데이터:', cardinals);
 
-  if (!Array.isArray(cardinals) || cardinals.length === 0) return '기수 없음';
+  if (!cardinals) return '기수 없음';
 
-  const validCardinals = cardinals.filter(
-    // eslint-disable-next-line no-restricted-globals
-    (c) => typeof c === 'number' && !isNaN(c),
-  );
+  let validCardinals: number[] = [];
+
+  if (typeof cardinals === 'string') {
+    validCardinals = (cardinals as string)
+      .split('.')
+      .map((c) => Number(c))
+      .filter((c) => !Number.isNaN(c));
+  } else if (Array.isArray(cardinals)) {
+    validCardinals = cardinals.filter(
+      (c) => typeof c === 'number' && !Number.isNaN(c),
+    );
+  }
 
   if (validCardinals.length === 0) return '기수 없음';
 

--- a/src/components/Admin/Modal/MemberDetailModal.tsx
+++ b/src/components/Admin/Modal/MemberDetailModal.tsx
@@ -5,20 +5,36 @@ import ButtonGroup from '@/components/Admin/ButtonGroup';
 import StatusIndicator from '@/components/Admin/StatusIndicator';
 import CommonModal from '@/components/Admin/Modal/CommonModal';
 import useAdminActions from '@/hooks/admin/useAdminActions';
+import { useRef, useState } from 'react';
+import CardinalEditModal from './CardinalEditModal';
 
 interface MemberDetailModalProps {
   data: MemberData;
   onClose: () => void;
 }
 
-const getHighestCardinal = (cardinals: string): string =>
-  `${cardinals.split('.')[0]}기`;
+const getHighestCardinal = (cardinals: number[] | undefined | null): string => {
+  console.log('기수 데이터:', cardinals);
+
+  if (!Array.isArray(cardinals) || cardinals.length === 0) return '기수 없음';
+
+  const validCardinals = cardinals.filter(
+    // eslint-disable-next-line no-restricted-globals
+    (c) => typeof c === 'number' && !isNaN(c),
+  );
+
+  if (validCardinals.length === 0) return '기수 없음';
+
+  return `${Math.max(...validCardinals)}기`;
+};
 
 const MemberDetailModal: React.FC<MemberDetailModalProps> = ({
   data,
   onClose,
 }) => {
   const { handleAction } = useAdminActions();
+  const [isCardinalModalOpen, setIsCardinalModalOpen] = useState(false);
+  const directInputButtonRef = useRef<HTMLDivElement>(null);
 
   const roleChangeButton =
     data.role === 'ADMIN'
@@ -47,7 +63,7 @@ const MemberDetailModal: React.FC<MemberDetailModalProps> = ({
     },
     {
       label: '직접 입력',
-      onClick: () => alert('직접 입력'),
+      onClick: () => setIsCardinalModalOpen(true),
       icon: dropdownIcon,
     },
     { label: '완료', onClick: onClose },
@@ -63,7 +79,7 @@ const MemberDetailModal: React.FC<MemberDetailModalProps> = ({
   ];
 
   const activityInfo = [
-    { label: '활동기수', value: data.cardinals },
+    { label: '활동기수', value: getHighestCardinal(data.cardinals) },
     { label: '상태', value: data.membershipType },
     { label: '가입일', value: data.createdAt },
     { label: '출석', value: data.attendanceCount },
@@ -72,66 +88,76 @@ const MemberDetailModal: React.FC<MemberDetailModalProps> = ({
   ];
 
   return (
-    <CommonModal
-      isOpen
-      onClose={onClose}
-      title="멤버 관리 버튼"
-      footer={<ButtonGroup buttons={buttons} hasEndGap />}
-    >
-      <S.ContentWrapper>
-        <S.ModalContent>
-          <S.FontStyle fontSize="12px" color="#000">
-            회원정보
-          </S.FontStyle>
-          <S.FlexWrapper>
-            <S.FontStyle fontSize="24px" fontWeight="700" color="#000">
-              {data.name} &nbsp;
-              {getHighestCardinal(data.cardinals)}
+    <>
+      <CommonModal
+        isOpen
+        onClose={onClose}
+        title="멤버 관리 버튼"
+        footer={<ButtonGroup buttons={buttons} hasEndGap />}
+      >
+        <S.ContentWrapper>
+          <S.ModalContent>
+            <S.FontStyle fontSize="12px" color="#000">
+              회원정보
             </S.FontStyle>
-            <StatusIndicator status={data.status} />
-          </S.FlexWrapper>
-          <S.FlexWrapper>
-            <S.LabelFlex>
-              {memberInfo.map((info) => (
-                <S.FontStyle key={info.label}>{info.label}</S.FontStyle>
-              ))}
-            </S.LabelFlex>
-            <S.DataFlex>
-              {memberInfo.map((info) => (
-                <S.FontStyle
-                  key={info.label}
-                  color={info.label === '패널티' ? '#ff5858' : undefined}
-                >
-                  {info.value}
-                </S.FontStyle>
-              ))}
-            </S.DataFlex>
-          </S.FlexWrapper>
-        </S.ModalContent>
-        <S.ActivityContent>
-          <S.FontStyle fontSize="12px" color="#000">
-            활동정보
-          </S.FontStyle>
-          <S.FlexWrapper>
-            <S.LabelFlex>
-              {activityInfo.map((info) => (
-                <S.FontStyle key={info.label}>{info.label}</S.FontStyle>
-              ))}
-            </S.LabelFlex>
-            <S.DataFlex>
-              {activityInfo.map((info) => (
-                <S.FontStyle
-                  key={info.label}
-                  color={info.label === '패널티' ? '#ff5858' : undefined}
-                >
-                  {info.value}
-                </S.FontStyle>
-              ))}
-            </S.DataFlex>
-          </S.FlexWrapper>
-        </S.ActivityContent>
-      </S.ContentWrapper>
-    </CommonModal>
+            <S.FlexWrapper>
+              <S.FontStyle fontSize="24px" fontWeight="700" color="#000">
+                {data.name} &nbsp;
+                {getHighestCardinal(data.cardinals)}
+              </S.FontStyle>
+              <StatusIndicator status={data.status} />
+            </S.FlexWrapper>
+            <S.FlexWrapper>
+              <S.LabelFlex>
+                {memberInfo.map((info) => (
+                  <S.FontStyle key={info.label}>{info.label}</S.FontStyle>
+                ))}
+              </S.LabelFlex>
+              <S.DataFlex>
+                {memberInfo.map((info) => (
+                  <S.FontStyle
+                    key={info.label}
+                    color={info.label === '패널티' ? '#ff5858' : undefined}
+                  >
+                    {info.value}
+                  </S.FontStyle>
+                ))}
+              </S.DataFlex>
+            </S.FlexWrapper>
+          </S.ModalContent>
+          <S.ActivityContent>
+            <S.FontStyle fontSize="12px" color="#000">
+              활동정보
+            </S.FontStyle>
+            <S.FlexWrapper>
+              <S.LabelFlex>
+                {activityInfo.map((info) => (
+                  <S.FontStyle key={info.label}>{info.label}</S.FontStyle>
+                ))}
+              </S.LabelFlex>
+              <S.DataFlex>
+                {activityInfo.map((info) => (
+                  <S.FontStyle
+                    key={info.label}
+                    color={info.label === '패널티' ? '#ff5858' : undefined}
+                  >
+                    {info.value}
+                  </S.FontStyle>
+                ))}
+              </S.DataFlex>
+            </S.FlexWrapper>
+          </S.ActivityContent>
+        </S.ContentWrapper>
+      </CommonModal>
+
+      {isCardinalModalOpen && (
+        <CardinalEditModal
+          isOpen={isCardinalModalOpen}
+          onClose={() => setIsCardinalModalOpen(false)}
+          selectedUserIds={[data.id]}
+        />
+      )}
+    </>
   );
 };
 

--- a/src/components/Admin/Modal/MemberDetailModal.tsx
+++ b/src/components/Admin/Modal/MemberDetailModal.tsx
@@ -5,7 +5,7 @@ import ButtonGroup from '@/components/Admin/ButtonGroup';
 import StatusIndicator from '@/components/Admin/StatusIndicator';
 import CommonModal from '@/components/Admin/Modal/CommonModal';
 import useAdminActions from '@/hooks/admin/useAdminActions';
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import getHighestCardinal from '@/utils/admin/getHighestCardinal';
 import CardinalEditModal from './CardinalEditModal';
 
@@ -20,7 +20,6 @@ const MemberDetailModal: React.FC<MemberDetailModalProps> = ({
 }) => {
   const { handleAction } = useAdminActions();
   const [isCardinalModalOpen, setIsCardinalModalOpen] = useState(false);
-  const directInputButtonRef = useRef<HTMLDivElement>(null);
 
   const roleChangeButton =
     data.role === 'ADMIN'

--- a/src/components/Admin/Modal/MemberDetailModal.tsx
+++ b/src/components/Admin/Modal/MemberDetailModal.tsx
@@ -7,7 +7,7 @@ import CommonModal from '@/components/Admin/Modal/CommonModal';
 import useAdminActions from '@/hooks/admin/useAdminActions';
 import { useState } from 'react';
 import getHighestCardinal from '@/utils/admin/getHighestCardinal';
-import CardinalEditModal from './CardinalEditModal';
+import CardinalEditModal from '@/components/Admin/Modal/CardinalEditModal';
 
 interface MemberDetailModalProps {
   data: MemberData;

--- a/src/components/Admin/Modal/MemberDetailModal.tsx
+++ b/src/components/Admin/Modal/MemberDetailModal.tsx
@@ -8,6 +8,7 @@ import useAdminActions from '@/hooks/admin/useAdminActions';
 import { useState } from 'react';
 import getHighestCardinal from '@/utils/admin/getHighestCardinal';
 import CardinalEditModal from '@/components/Admin/Modal/CardinalEditModal';
+import theme from '@/styles/theme';
 
 interface MemberDetailModalProps {
   data: MemberData;
@@ -47,9 +48,14 @@ const MemberDetailModal: React.FC<MemberDetailModalProps> = ({
       onClick: () => handleAction('유저 추방', [data.id]),
     },
     {
-      label: '직접 입력',
+      label: '기수 변경',
       onClick: () => setIsCardinalModalOpen(true),
-      icon: dropdownIcon,
+      style: {
+        backgroundColor: isCardinalModalOpen
+          ? theme.color.gray[18]
+          : theme.color.gray[100],
+        color: isCardinalModalOpen ? theme.color.gray[100] : '#000',
+      },
     },
     { label: '완료', onClick: onClose },
   ];
@@ -134,12 +140,13 @@ const MemberDetailModal: React.FC<MemberDetailModalProps> = ({
           </S.ActivityContent>
         </S.ContentWrapper>
       </CommonModal>
-
       {isCardinalModalOpen && (
         <CardinalEditModal
           isOpen={isCardinalModalOpen}
           onClose={() => setIsCardinalModalOpen(false)}
           selectedUserIds={[data.id]}
+          top="26%"
+          left="38%"
         />
       )}
     </>

--- a/src/components/Admin/Modal/MemberDetailModal.tsx
+++ b/src/components/Admin/Modal/MemberDetailModal.tsx
@@ -6,35 +6,13 @@ import StatusIndicator from '@/components/Admin/StatusIndicator';
 import CommonModal from '@/components/Admin/Modal/CommonModal';
 import useAdminActions from '@/hooks/admin/useAdminActions';
 import { useRef, useState } from 'react';
+import getHighestCardinal from '@/utils/admin/getHighestCardinal';
 import CardinalEditModal from './CardinalEditModal';
 
 interface MemberDetailModalProps {
   data: MemberData;
   onClose: () => void;
 }
-
-const getHighestCardinal = (cardinals: number[] | undefined | null): string => {
-  console.log('기수 데이터:', cardinals);
-
-  if (!cardinals) return '기수 없음';
-
-  let validCardinals: number[] = [];
-
-  if (typeof cardinals === 'string') {
-    validCardinals = (cardinals as string)
-      .split('.')
-      .map((c) => Number(c))
-      .filter((c) => !Number.isNaN(c));
-  } else if (Array.isArray(cardinals)) {
-    validCardinals = cardinals.filter(
-      (c) => typeof c === 'number' && !Number.isNaN(c),
-    );
-  }
-
-  if (validCardinals.length === 0) return '기수 없음';
-
-  return `${Math.max(...validCardinals)}기`;
-};
 
 const MemberDetailModal: React.FC<MemberDetailModalProps> = ({
   data,
@@ -87,7 +65,7 @@ const MemberDetailModal: React.FC<MemberDetailModalProps> = ({
   ];
 
   const activityInfo = [
-    { label: '활동기수', value: getHighestCardinal(data.cardinals) },
+    { label: '활동기수', value: data.cardinals },
     { label: '상태', value: data.membershipType },
     { label: '가입일', value: data.createdAt },
     { label: '출석', value: data.attendanceCount },

--- a/src/components/Admin/Modal/MemberDetailModal.tsx
+++ b/src/components/Admin/Modal/MemberDetailModal.tsx
@@ -1,6 +1,5 @@
 import { MemberData } from '@/components/Admin/context/MemberContext';
 import * as S from '@/styles/admin/cardinal/CardinalModal.styled';
-import dropdownIcon from '@/assets/images/ic_admin_column_meatball.svg';
 import ButtonGroup from '@/components/Admin/ButtonGroup';
 import StatusIndicator from '@/components/Admin/StatusIndicator';
 import CommonModal from '@/components/Admin/Modal/CommonModal';

--- a/src/components/Admin/NavMenuList.tsx
+++ b/src/components/Admin/NavMenuList.tsx
@@ -43,7 +43,7 @@ const NavMenuList: React.FC = () => {
     {
       id: 'penalty',
       icon: <PenaltyIcon />,
-      label: '페널티 관리',
+      label: '패널티 관리',
       path: '/admin/penalty',
     },
     {
@@ -64,7 +64,7 @@ const NavMenuList: React.FC = () => {
     {
       id: 'manual',
       icon: <ManualIcon />,
-      label: '관리자 메뉴얼',
+      label: '관리자 매뉴얼',
       path: '', // 추후 수정
     },
   ];

--- a/src/components/Admin/PenaltyListTable.tsx
+++ b/src/components/Admin/PenaltyListTable.tsx
@@ -26,11 +26,37 @@ const columns = [
   { key: 'empty', header: '' },
 ];
 
-const PenaltyListTable: React.FC = () => {
-  const { filteredMembers } = useMemberContext();
-  const StatusfilteredMembers = filteredMembers.filter(
-    (member) => member.status === '승인 완료',
-  );
+interface PenaltyListTableProps {
+  selectedCardinal: number | null;
+}
+
+const PenaltyListTable: React.FC<PenaltyListTableProps> = ({
+  selectedCardinal,
+}) => {
+  const { members } = useMemberContext();
+  const [filteredMembers, setFilteredMembers] = useState(members);
+
+  useEffect(() => {
+    const newFilteredMembers = members.filter((member) => {
+      const isApproved = member.status === '승인 완료';
+
+      if (selectedCardinal) {
+        let cardinalNumbers: number[] = [];
+
+        if (typeof member.cardinals === 'string') {
+          cardinalNumbers = (member.cardinals as string).split('.').map(Number);
+        } else if (Array.isArray(member.cardinals)) {
+          cardinalNumbers = member.cardinals as number[];
+        }
+
+        return isApproved && cardinalNumbers.includes(selectedCardinal);
+      }
+
+      return isApproved;
+    });
+
+    setFilteredMembers(newFilteredMembers);
+  }, [selectedCardinal, members]);
 
   const [expandedRow, setExpandedRow] = useState<number | null>(null);
   const [isAdding, setIsAdding] = useState<boolean>(false);
@@ -163,7 +189,7 @@ const PenaltyListTable: React.FC = () => {
             </tr>
           </thead>
           <tbody>
-            {StatusfilteredMembers.map((member) => (
+            {filteredMembers.map((member) => (
               <React.Fragment key={member.id}>
                 <S.Row
                   isSelected={expandedRow === member.id}

--- a/src/components/Admin/SearchBar.tsx
+++ b/src/components/Admin/SearchBar.tsx
@@ -28,6 +28,7 @@ export const StyledInput = styled.input`
   &::placeholder {
     color: ${theme.color.gray[20]};
   }
+  outline: none;
 `;
 
 export const SearchBarIcon = styled.img<{ isWrapped?: boolean }>`

--- a/src/components/Admin/SortButton.tsx
+++ b/src/components/Admin/SortButton.tsx
@@ -22,7 +22,7 @@ const SortButton: React.FC = () => {
   };
   return (
     <SortButtonWrapper onClick={onClickSort}>
-      {sortingOrder === 'NAME_ASCENDING' ? '오름차순' : '기수 순'}
+      {sortingOrder === 'NAME_ASCENDING' ? '이름순' : '기수순'}
       <img src={SortIcon} alt="sorting" />
     </SortButtonWrapper>
   );

--- a/src/components/Admin/context/MemberContext.tsx
+++ b/src/components/Admin/context/MemberContext.tsx
@@ -8,7 +8,7 @@ export type MemberData = {
   name: string;
   role: string;
   department: string;
-  cardinals: string;
+  cardinals: number[];
   tel: string;
   studentId: string;
   position: string;
@@ -32,6 +32,8 @@ interface MemberContextProps {
   setSortingOrder: React.Dispatch<
     React.SetStateAction<'NAME_ASCENDING' | 'CARDINAL_DESCENDING'>
   >;
+  selectedCardinal: number | null;
+  setSelectedCardinal: React.Dispatch<React.SetStateAction<number | null>>;
 }
 
 // context 생성
@@ -52,6 +54,8 @@ export const MemberProvider: React.FC<{ children: React.ReactNode }> = ({
     'NAME_ASCENDING' | 'CARDINAL_DESCENDING'
   >('NAME_ASCENDING');
 
+  const [selectedCardinal, setSelectedCardinal] = useState<number | null>(null);
+
   const statusMapping: Record<string, string> = {
     ACTIVE: '승인 완료',
     WAITING: '대기 중',
@@ -69,7 +73,7 @@ export const MemberProvider: React.FC<{ children: React.ReactNode }> = ({
           ...user,
           cardinals:
             user.cardinals.length > 0 ? user.cardinals.reverse().join('.') : '',
-          status: statusMapping[user.status] || '추방',
+          status: statusMapping[user.status] || '대기 중',
           attendanceCount: user.attendanceCount ?? 0,
           absenceCount: user.absenceCount ?? 0,
           penaltyCount: user.penaltyCount ?? 0,
@@ -85,6 +89,20 @@ export const MemberProvider: React.FC<{ children: React.ReactNode }> = ({
 
     fetchMembers();
   }, [sortingOrder]);
+
+  useEffect(() => {
+    if (selectedCardinal === null) {
+      setFilteredMembers(members);
+      return;
+    }
+
+    const filtered = members.filter((member) => {
+      return member.cardinals.includes(selectedCardinal);
+    });
+
+    setFilteredMembers(filtered);
+  }, [selectedCardinal, members]);
+
   const value = useMemo(
     () => ({
       members,
@@ -95,8 +113,10 @@ export const MemberProvider: React.FC<{ children: React.ReactNode }> = ({
       setFilteredMembers,
       sortingOrder,
       setSortingOrder,
+      selectedCardinal,
+      setSelectedCardinal,
     }),
-    [members, selectedMembers, filteredMembers, error],
+    [members, selectedMembers, filteredMembers, selectedCardinal, error],
   );
 
   return (

--- a/src/pages/admin/AdminPenalty.tsx
+++ b/src/pages/admin/AdminPenalty.tsx
@@ -1,8 +1,5 @@
 import CardinalSearchBar from '@/components/Admin/CardinalSearchBar';
-import {
-  MemberProvider,
-  // useMemberContext,
-} from '@/components/Admin/context/MemberContext';
+import { MemberProvider } from '@/components/Admin/context/MemberContext';
 import NavMenu from '@/components/Admin/NavMenu';
 import PenaltyListTable from '@/components/Admin/PenaltyListTable';
 import TopBar from '@/components/Admin/TopBar';
@@ -16,17 +13,6 @@ import { useState } from 'react';
 
 const AdminPenalty: React.FC = () => {
   const [selectedCardinal, setSelectedCardinal] = useState<null | number>(null);
-  // const { members } = useMemberContext();
-
-  // const filteredMembers = selectedCardinal
-  //   ? members.filter((member) => {
-  //       const cardinalNumbers = Array.isArray(member.cardinals)
-  //         ? member.cardinals.map(Number)
-  //         : [Number(member.cardinals)];
-
-  //       return cardinalNumbers.includes(selectedCardinal);
-  //     })
-  //   : members;
 
   return (
     <MemberProvider>
@@ -43,8 +29,7 @@ const AdminPenalty: React.FC = () => {
               selectedCardinal={selectedCardinal}
               setSelectedCardinal={setSelectedCardinal}
             />
-            {/* <PenaltyListTable members={filteredMembers} /> */}
-            <PenaltyListTable />
+            <PenaltyListTable selectedCardinal={selectedCardinal} />
           </Container>
         </ContentWrapper>
       </PageWrapper>

--- a/src/styles/admin/cardinal/CardinalInfo.styled.ts
+++ b/src/styles/admin/cardinal/CardinalInfo.styled.ts
@@ -12,14 +12,6 @@ export const TotalBox = styled(Box)`
   background-color: ${theme.color.gray[18]};
 `;
 
-export const CardinalBox = styled(Box)<{ isIncomplete?: boolean }>`
-  ${({ isIncomplete }) =>
-    isIncomplete
-      ? `border: 2px dashed ${theme.color.gray[18]}; 
-      background-color:transparent`
-      : ''}
-`;
-
 export const ScrollContainer = styled.div`
   display: flex;
   gap: 16px;

--- a/src/styles/admin/cardinal/CardinalInfo.styled.ts
+++ b/src/styles/admin/cardinal/CardinalInfo.styled.ts
@@ -14,7 +14,10 @@ export const TotalBox = styled(Box)`
 
 export const CardinalBox = styled(Box)<{ isIncomplete?: boolean }>`
   ${({ isIncomplete }) =>
-    isIncomplete ? `border: 2px dashed ${theme.color.gray[18]};` : ''}
+    isIncomplete
+      ? `border: 2px dashed ${theme.color.gray[18]}; 
+      background-color:transparent`
+      : ''}
 `;
 
 export const ScrollContainer = styled.div`

--- a/src/styles/admin/cardinal/CardinalModal.styled.ts
+++ b/src/styles/admin/cardinal/CardinalModal.styled.ts
@@ -122,7 +122,9 @@ export const StyledInput = styled.input<{ flex: number; maxWidth: string }>`
   border-radius: 4px;
   font-size: 16px;
   padding: 12px;
-
+  &::focus {
+    outline: 2px solid #2f2f2f;
+  }
   &::placeholder {
     color: ${theme.color.gray[65]};
   }

--- a/src/styles/admin/cardinal/CardinalModal.styled.ts
+++ b/src/styles/admin/cardinal/CardinalModal.styled.ts
@@ -137,26 +137,44 @@ export const StyledInput = styled.input<{ flex: number; maxWidth: string }>`
 `;
 
 // CardinalModal.tsx
-export const Input = styled.input`
+export const InputWrapper = styled.div`
+  display: flex;
+  align-items: center;
   width: 100%;
   max-width: 100%;
-  padding: 15px;
+  padding: 10px;
   box-sizing: border-box;
-  border: 1px solid #ddd;
+  border: 1px solid #dedede;
   font-size: 16px;
-  font-family: ${theme.font.semiBold};
   outline: none;
-  text-align: right;
 
   :focus::placeholder {
     color: transparent;
   }
 `;
 
+export const Input = styled.input`
+  font-family: ${theme.font.semiBold};
+  font-size: 18px;
+  flex-grow: 1;
+  width: 50%;
+  border: none;
+  outline: none;
+  text-align: right;
+  padding: 5px;
+`;
+
+export const Unit = styled.div`
+  font-size: 18px;
+  color: ${theme.color.gray[65]};
+  white-space: nowrap;
+`;
+
 export const Title = styled.div`
-  font-weight: 500;
-  font-size: 16px;
-  color: #000;
+  font-weight: 700;
+  font-size: 24px;
+  margin-top: -30px;
+  padding-bottom: 10px;
 `;
 
 export const FlexRow = styled.div`

--- a/src/styles/admin/cardinal/CardinalModal.styled.ts
+++ b/src/styles/admin/cardinal/CardinalModal.styled.ts
@@ -122,20 +122,25 @@ export const StyledInput = styled.input<{ flex: number; maxWidth: string }>`
   border-radius: 4px;
   font-size: 16px;
   padding: 12px;
-  &::focus {
-    outline: 2px solid #2f2f2f;
-  }
   &::placeholder {
     color: ${theme.color.gray[65]};
   }
 
   // readOnly 일 때 색상 변경
   ${({ readOnly }) =>
-    readOnly &&
-    `
-    color: ${theme.color.gray[65]};
-    cursor: not-allowed;
-  `}
+    readOnly
+      ? `
+      color: ${theme.color.gray[65]};
+      cursor: not-allowed;
+      &:focus {
+      outline: none
+      }
+      `
+      : `
+      &:focus {
+      outline: 2px solid #2f2f2f;
+      }
+    `}
 `;
 
 // CardinalModal.tsx

--- a/src/styles/admin/cardinal/CardinalModal.styled.ts
+++ b/src/styles/admin/cardinal/CardinalModal.styled.ts
@@ -160,7 +160,7 @@ export const InputWrapper = styled.div`
   }
 `;
 
-export const Input = styled.input`
+export const Input = styled.input<{ readOnly?: boolean }>`
   font-family: ${theme.font.semiBold};
   font-size: 18px;
   flex-grow: 1;
@@ -169,6 +169,13 @@ export const Input = styled.input`
   outline: none;
   text-align: right;
   padding: 5px;
+
+  ${({ readOnly }) =>
+    readOnly &&
+    `
+    color: ${theme.color.gray[65]};
+    cursor: not-allowed;
+  `}
 `;
 
 export const Unit = styled.div`

--- a/src/utils/admin/getHighestCardinal.ts
+++ b/src/utils/admin/getHighestCardinal.ts
@@ -1,0 +1,22 @@
+const getHighestCardinal = (cardinals: number[] | undefined | null): string => {
+  if (!cardinals) return '기수 없음';
+
+  let validCardinals: number[] = [];
+
+  if (typeof cardinals === 'string') {
+    validCardinals = (cardinals as string)
+      .split('.')
+      .map((c) => Number(c))
+      .filter((c) => !Number.isNaN(c));
+  } else if (Array.isArray(cardinals)) {
+    validCardinals = cardinals.filter(
+      (c) => typeof c === 'number' && !Number.isNaN(c),
+    );
+  }
+
+  if (validCardinals.length === 0) return '기수 없음';
+
+  return `${Math.max(...validCardinals)}기`;
+};
+
+export default getHighestCardinal;

--- a/src/utils/admin/handleNumericInput.ts
+++ b/src/utils/admin/handleNumericInput.ts
@@ -1,0 +1,33 @@
+// 숫자 이외의 문자 제거
+const handleNumericInput = (
+  e: React.ChangeEvent<HTMLInputElement>,
+  setState: React.Dispatch<React.SetStateAction<any>>,
+  maxLength?: number, // 입력 가능한 최대 길이
+  allowedValues?: string[], // 허용할 값 리스트 ( 학기: ['1', '2'])
+) => {
+  const { name, value } = e.target;
+
+  let numericValue = value.replace(/[^0-9]/g, '');
+
+  if (maxLength) {
+    numericValue = numericValue.slice(0, maxLength);
+  }
+
+  if (allowedValues && !allowedValues.includes(numericValue)) {
+    numericValue = '';
+  }
+
+  setState((prev: any) => ({
+    ...prev,
+    [name]: numericValue,
+  }));
+};
+
+const preventNonNumeric = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  // 숫자 키, 백스페이스, 삭제키만 허용
+  if (!/[0-9]/.test(e.key) && e.key !== 'Backspace' && e.key !== 'Delete') {
+    e.preventDefault();
+  }
+};
+
+export { preventNonNumeric, handleNumericInput };


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
#377 를 구현하였습니다.
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
기수 수정할 때 이미 저장된 연도 및 학기일 경우를 수정이 안되도록 하는게 좋지 않을까 싶은데.. 배겐드에게 물어봐야 할듯.. 
그래서 현재 8기,9기가 모두 2026년 2학기라는 점.. 
![image](https://github.com/user-attachments/assets/f16d40df-92d9-45f1-8a2a-9d0cb6e1e05e)

-> 회의 때 말한대로 그정돈 유저의 책임으로 전가하도록 
<br>

## 3. 관련 스크린샷을 첨부해주세요.

####  - 선택 멤버를 임시 기수로 변경했을 때 
![image](https://github.com/user-attachments/assets/e9d7aa6e-f88e-45e6-9b55-6560ce6ec358)

#### - 임시 기수(9기) 를 클릭했을 때 뜨는 모달 ( 우선 제가 임의로 수정한거라 디자인은 수정될 수도.. ) 
![image](https://github.com/user-attachments/assets/b84a1695-32bf-4d33-9892-cde1fc676fcd)

####  - 기수 정보를 수정한 후 기수 수정 api 요청 
![image](https://github.com/user-attachments/assets/119dbd63-0dda-4a71-bf75-4cc24099f843)

#### - 페널티 관리 페이지 기수 필터링 
![image](https://github.com/user-attachments/assets/e706b8b8-8970-4e31-a787-735f0be26852)

#### - 멤버 관리 페이지 기수 필터링 
![image](https://github.com/user-attachments/assets/3109a3a4-359f-4548-a785-47ff056760e2)

나머지는 자잘한거라.... 이정도만 첨부하겠습니다
<br>

## 4. 완료 사항
구현하지 못한 기수 관련된 수정사항들을 모두 구현했습니다 .............. 
 
- [x] 기수 수정 api 연결
- [x] 멤버 상세 관리 상태 추가 ( 활동중 or 알럼나이)
- [x] 멤버 상세 관리 기수 드롭다운 연결 및 기수 변경 모달/ 완료버튼 위치 수정
- [x] 멤버 상세 관리 모달 기수 오류 문제 수정
- [x] 기수 추가 모달 - 현재 진행 중 체크 시 "현재"로 표시
- [x] 학기 정보가 완벽하게 입력되지 않은 기수 컴포일 경우 ui 수정
- [x] 기수 모달 열렸을 때 네비바 로고 쪽에 모달이 하나 더 생기는 오류 해결
- [x] 페널티 페이지 - 기수 선택 시 해당 기수의 멤버만 보여주도록  필터링
- [x] 기수 추가 모달 변경된 ui 적용 ( + 기수 수정일 경우 타이틀 변경) 
- [x] 기수 드롭다운 기수 선택 시 해당 기수가 드롭다운에 보이지 않는 문제 수정
- [x] 멤버 관리 페이지 - 기수 컴포넌트 클릭 시 해당 기수에 해당하는 멤버만 필터링되도록 수정

<br>

## 5. 추가 사항
이제 남은 건 qa 수정.. 신난다 ! 
<br>
