### PR TITLE
[hotfix] #426 BASE_URL 배포 환경 따라 동적 할당

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,7 +1,10 @@
 import axios, { AxiosHeaders, type InternalAxiosRequestConfig } from 'axios';
 
 // API URL
-const BASE_URL = import.meta.env.VITE_API_URL;
+const BASE_URL =
+  window.location.hostname === 'weeth.site'
+    ? import.meta.env.VITE_API_URL
+    : import.meta.env.VITE_API_URL_DEV;
 
 // Axios 인스턴스 생성
 const api = axios.create({

--- a/src/api/deleteComment.tsx
+++ b/src/api/deleteComment.tsx
@@ -1,6 +1,9 @@
 import api from '@/api/api';
 
-const BASE_URL = import.meta.env.VITE_API_URL;
+const BASE_URL =
+  window.location.hostname === 'weeth.site'
+    ? import.meta.env.VITE_API_URL
+    : import.meta.env.VITE_API_URL_DEV;
 
 const deleteComment = async (
   path: string,

--- a/src/api/deletePost.tsx
+++ b/src/api/deletePost.tsx
@@ -1,6 +1,9 @@
 import api from '@/api/api';
 
-const BASE_URL = import.meta.env.VITE_API_URL;
+const BASE_URL =
+  window.location.hostname === 'weeth.site'
+    ? import.meta.env.VITE_API_URL
+    : import.meta.env.VITE_API_URL_DEV;
 
 const deletePost = async (postId: number, path: string) => {
   const url =

--- a/src/api/patchAttend.tsx
+++ b/src/api/patchAttend.tsx
@@ -4,7 +4,10 @@ interface AttendCheckType {
   code: string;
 }
 
-const BASE_URL = import.meta.env.VITE_API_URL;
+const BASE_URL =
+  window.location.hostname === 'weeth.site'
+    ? import.meta.env.VITE_API_URL
+    : import.meta.env.VITE_API_URL_DEV;
 
 export const patchAttend = async (data: AttendCheckType) => {
   try {

--- a/src/api/postComment.tsx
+++ b/src/api/postComment.tsx
@@ -1,6 +1,9 @@
 import api from '@/api/api';
 
-const BASE_URL = import.meta.env.VITE_API_URL;
+const BASE_URL =
+  window.location.hostname === 'weeth.site'
+    ? import.meta.env.VITE_API_URL
+    : import.meta.env.VITE_API_URL_DEV;
 
 // 대댓글일 경우만 parentCommentId 보내주기
 const createComment = async (

--- a/src/api/uploadFiles.tsx
+++ b/src/api/uploadFiles.tsx
@@ -2,7 +2,10 @@
 import axios from 'axios';
 import qs from 'qs';
 
-const BASE_URL = import.meta.env.VITE_API_URL;
+const BASE_URL =
+  window.location.hostname === 'weeth.site'
+    ? import.meta.env.VITE_API_URL
+    : import.meta.env.VITE_API_URL_DEV;
 const accessToken = localStorage.getItem('accessToken');
 const refreshToken = localStorage.getItem('refreshToken');
 

--- a/src/api/useGetBoardDetail.tsx
+++ b/src/api/useGetBoardDetail.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useState } from 'react';
 import api from '@/api/api';
 
-const BASE_URL = import.meta.env.VITE_API_URL;
+const BASE_URL =
+  window.location.hostname === 'weeth.site'
+    ? import.meta.env.VITE_API_URL
+    : import.meta.env.VITE_API_URL_DEV;
 
 interface Comments {
   id: number;

--- a/src/api/useGetBoardInfo.tsx
+++ b/src/api/useGetBoardInfo.tsx
@@ -25,7 +25,10 @@ interface ApiResponse {
   };
 }
 
-const BASE_URL = import.meta.env.VITE_API_URL;
+const BASE_URL =
+  window.location.hostname === 'weeth.site'
+    ? import.meta.env.VITE_API_URL
+    : import.meta.env.VITE_API_URL_DEV;
 
 export const useGetBoardInfo = async (
   path: string,

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -96,7 +96,6 @@ const Landing: React.FC = () => {
           color={theme.color.kakao}
           textcolor="#000000"
           onClick={() => {
-            console.log(kakaoURL);
             window.location.href = kakaoURL;
           }}
         >

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -81,7 +81,10 @@ const Signup: React.FC = () => {
     DuplicatedEmail: string,
   ): Promise<boolean | null> => {
     try {
-      const BASE_URL = import.meta.env.VITE_API_URL;
+      const BASE_URL =
+        window.location.hostname === 'weeth.site'
+          ? import.meta.env.VITE_API_URL
+          : import.meta.env.VITE_API_URL_DEV;
       const response = await axios.get(
         `${BASE_URL}/api/v1/users/email?email=${DuplicatedEmail}`,
       );


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?

BASE_URL을 배포 환경에 따라 동적할당 할 수 있도록 코드를 수정하였습니다.

<br>

## 2. 어떤 위험이나 장애를 발견했나요?

window.location.hostname이 서비스 배포 환경인 weeth.site가 아닌 경우,
즉, 개발 배포 환경 또는 로컬 환경에서는 개발 서버로 보내게 수정하였습니다.

<br>

## 3. 관련 스크린샷을 첨부해주세요.

<br>

## 4. 완료 사항

<br>

## 5. 추가 사항

<br>
