### PR TITLE
[FIX] 7기 학과 어드민 매핑 상수 수정

### DIFF
--- a/src/constants/departmentConstants.ts
+++ b/src/constants/departmentConstants.ts
@@ -11,6 +11,9 @@ export const department: { [key: string]: string } = {
   GLOBAL_BUSINESS: '글로벌경영학과',
   FINANCIAL_MATHMATICS: '금융수학전공',
   HEALTHCARE_MANAGEMENT: '의료산업경영학과',
+  GAME_AND_INTERACTIVE_MEDIA: '게임영상학과',
+  ENGLISH_LANGUAGE: '영미어문학과',
+  PSYCHOLOGY: '심리학과',
 };
 
 export default department;


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?

<br>

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

## 3. 관련 스크린샷을 첨부해주세요.

<br>

## 4. 완료 사항
- 어드민에서 게임영상학과, 심리학과, 영미어문학과 과 매핑 상수를 수정했습니다.
<br>

## 5. 추가 사항

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신기능**
  * 게임영상학과, 영미어문학과, 심리학과 3개 학과가 시스템에 새로 추가되었습니다. 사용자는 이제 이 학과들을 선택하고 활용할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->